### PR TITLE
Fix the equijoins condition

### DIFF
--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -179,6 +179,13 @@ class LogicalJoinPlugin(BaseRelPlugin):
             lhs_index = operand_lhs.getIndex()
             rhs_index = operand_rhs.getIndex()
 
+            # The rhs table always comes after the lhs
+            # table. Therefore we have a very simple
+            # way of checking, which index comes from which
+            # input
+            if lhs_index > rhs_index:
+                lhs_index, rhs_index = rhs_index, lhs_index
+
             return lhs_index, rhs_index
 
         raise TypeError("Invalid join condition")  # pragma: no cover

--- a/tests/integration/test_join.py
+++ b/tests/integration/test_join.py
@@ -73,7 +73,7 @@ class JoinTestCase(DaskTestCase):
             lhs.user_id, lhs.b, rhs.user_id, rhs.c
         FROM user_table_2 AS lhs
         JOIN user_table_1 AS rhs
-            ON lhs.user_id = rhs.user_id AND lhs.b - rhs.c >= 0
+            ON rhs.user_id = lhs.user_id AND lhs.b - rhs.c >= 0
         """
         )
 


### PR DESCRIPTION
The current code assumes, that in equijoins the left operand always comes from the left table. 
That does not need to be the case.