### PR TITLE
Increase Speed

### DIFF
--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -1,0 +1,92 @@
+from typing import List, Dict, Tuple, Union
+
+import dask.dataframe as dd
+
+
+class ColumnContainer:
+    pass
+
+
+class ColumnContainer:
+    def __init__(
+        self,
+        frontend_columns: List[str],
+        frontend_backend_mapping: Union[Dict[str, str], None] = None,
+    ):
+        self._frontend_columns = list(frontend_columns)
+        if frontend_backend_mapping is None:
+            self._frontend_backend_mapping = {
+                col: col for col in self._frontend_columns
+            }
+        else:
+            self._frontend_backend_mapping = frontend_backend_mapping
+
+    def _copy(self) -> ColumnContainer:
+        return ColumnContainer(self._frontend_columns, self._frontend_backend_mapping)
+
+    def limit_to(self, fields: List[str]) -> ColumnContainer:
+        assert all(f in self._frontend_backend_mapping for f in fields)
+        cc = self._copy()
+        cc._frontend_columns = list(fields)
+        return cc
+
+    def rename(self, columns: Dict[str, str]) -> ColumnContainer:
+        cc = self._copy()
+        for column_from, column_to in columns.items():
+            backend_column = self._frontend_backend_mapping[column_from]
+            cc._frontend_backend_mapping[column_to] = backend_column
+
+        cc._frontend_columns = [
+            columns[col] if col in columns else col for col in self._frontend_columns
+        ]
+
+        return cc
+
+    def mapping(self) -> List[Tuple[str, str]]:
+        return self._frontend_backend_mapping.items()
+
+    def reverse_mapping(self) -> List[Tuple[str, str]]:
+        return {backend: frontend for frontend, backend in self.mapping()}
+
+    @property
+    def columns(self) -> List[str]:
+        return self._frontend_columns
+
+    def add(
+        self, frontend_column: str, backend_column: Union[str, None] = None
+    ) -> ColumnContainer:
+        cc = self._copy()
+
+        cc._frontend_backend_mapping[frontend_column] = (
+            backend_column or frontend_column
+        )
+        cc._frontend_columns.append(frontend_column)
+
+        return cc
+
+    def get_backend_by_frontend_index(self, index: int) -> str:
+        frontend_column = self._frontend_columns[index]
+        backend_column = self._frontend_backend_mapping[frontend_column]
+        return backend_column
+
+    def make_unique(self, prefix="col"):
+        """
+        Make sure we have unique column names by calling each column
+
+            prefix_number
+
+        where number is the column index.
+        """
+        return self.rename(
+            columns={col: f"{prefix}_{i}" for i, col in enumerate(self.columns)}
+        )
+
+
+class DataContainer:
+    def __init__(self, df: dd.DataFrame, column_container: ColumnContainer):
+        self.df = df
+        self.column_container = column_container
+
+    def assign(self) -> dd.DataFrame:
+        df = self.df.rename(columns=self.column_container.reverse_mapping())
+        return df[self.column_container.columns]

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -3,6 +3,9 @@ from typing import List, Dict, Tuple, Union
 import dask.dataframe as dd
 
 
+ColumnType = Union[str, int]
+
+
 class ColumnContainer:
     pass
 
@@ -11,8 +14,11 @@ class ColumnContainer:
     def __init__(
         self,
         frontend_columns: List[str],
-        frontend_backend_mapping: Union[Dict[str, str], None] = None,
+        frontend_backend_mapping: Union[Dict[str, ColumnType], None] = None,
     ):
+        assert all(
+            isinstance(col, str) for col in frontend_columns
+        ), "All frontend columns need to be of string type"
         self._frontend_columns = list(frontend_columns)
         if frontend_backend_mapping is None:
             self._frontend_backend_mapping = {
@@ -27,26 +33,24 @@ class ColumnContainer:
     def limit_to(self, fields: List[str]) -> ColumnContainer:
         assert all(f in self._frontend_backend_mapping for f in fields)
         cc = self._copy()
-        cc._frontend_columns = list(fields)
+        cc._frontend_columns = [str(x) for x in fields]
         return cc
 
-    def rename(self, columns: Dict[str, str]) -> ColumnContainer:
+    def rename(self, columns: Dict[str, ColumnType]) -> ColumnContainer:
         cc = self._copy()
         for column_from, column_to in columns.items():
-            backend_column = self._frontend_backend_mapping[column_from]
-            cc._frontend_backend_mapping[column_to] = backend_column
+            backend_column = self._frontend_backend_mapping[str(column_from)]
+            cc._frontend_backend_mapping[str(column_to)] = backend_column
 
         cc._frontend_columns = [
-            columns[col] if col in columns else col for col in self._frontend_columns
+            str(columns[col]) if col in columns else col
+            for col in self._frontend_columns
         ]
 
         return cc
 
     def mapping(self) -> List[Tuple[str, str]]:
-        return self._frontend_backend_mapping.items()
-
-    def reverse_mapping(self) -> List[Tuple[str, str]]:
-        return {backend: frontend for frontend, backend in self.mapping()}
+        return list(self._frontend_backend_mapping.items())
 
     @property
     def columns(self) -> List[str]:
@@ -57,7 +61,9 @@ class ColumnContainer:
     ) -> ColumnContainer:
         cc = self._copy()
 
-        cc._frontend_backend_mapping[frontend_column] = (
+        frontend_column = str(frontend_column)
+
+        cc._frontend_backend_mapping[frontend_column] = str(
             backend_column or frontend_column
         )
         cc._frontend_columns.append(frontend_column)
@@ -78,7 +84,7 @@ class ColumnContainer:
         where number is the column index.
         """
         return self.rename(
-            columns={col: f"{prefix}_{i}" for i, col in enumerate(self.columns)}
+            columns={str(col): f"{prefix}_{i}" for i, col in enumerate(self.columns)}
         )
 
 
@@ -88,5 +94,10 @@ class DataContainer:
         self.column_container = column_container
 
     def assign(self) -> dd.DataFrame:
-        df = self.df.rename(columns=self.column_container.reverse_mapping())
+        df = self.df.assign(
+            **{
+                col_from: self.df[col_to]
+                for col_from, col_to in self.column_container.mapping()
+            }
+        )
         return df[self.column_container.columns]

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -7,10 +7,20 @@ ColumnType = Union[str, int]
 
 
 class ColumnContainer:
+    # Forward declaration
     pass
 
 
 class ColumnContainer:
+    """
+    Helper class to store a list of columns,
+    which do not necessarily be the ones of the dask dataframe.
+    Instead, the container also stores a mapping from "frontend"
+    columns (columns with the names and order expected by SQL)
+    to "backend" columns (the real column names used by dask)
+    to prevent unnecessary renames.
+    """
+
     def __init__(
         self,
         frontend_columns: List[str],
@@ -28,15 +38,29 @@ class ColumnContainer:
             self._frontend_backend_mapping = frontend_backend_mapping
 
     def _copy(self) -> ColumnContainer:
+        """
+        Internal function to copy this container
+        """
         return ColumnContainer(self._frontend_columns, self._frontend_backend_mapping)
 
     def limit_to(self, fields: List[str]) -> ColumnContainer:
+        """
+        Create a new ColumnContainer, which has frontend columns
+        limited to only the ones given as parameter.
+        Also uses the order of these as the new column order.
+        """
         assert all(f in self._frontend_backend_mapping for f in fields)
         cc = self._copy()
         cc._frontend_columns = [str(x) for x in fields]
         return cc
 
-    def rename(self, columns: Dict[str, ColumnType]) -> ColumnContainer:
+    def rename(self, columns: Dict[str, str]) -> ColumnContainer:
+        """
+        Return a new ColumnContainer where the frontend columns
+        are renamed according to the given mapping.
+        Columns not present in the mapping are not touched,
+        the order is preserved.
+        """
         cc = self._copy()
         for column_from, column_to in columns.items():
             backend_column = self._frontend_backend_mapping[str(column_from)]
@@ -49,16 +73,27 @@ class ColumnContainer:
 
         return cc
 
-    def mapping(self) -> List[Tuple[str, str]]:
+    def mapping(self) -> List[Tuple[str, ColumnType]]:
+        """
+        The mapping from frontend columns to backend columns.
+        """
         return list(self._frontend_backend_mapping.items())
 
     @property
     def columns(self) -> List[str]:
+        """
+        The stored frontend columns in the correct order
+        """
         return self._frontend_columns
 
     def add(
         self, frontend_column: str, backend_column: Union[str, None] = None
     ) -> ColumnContainer:
+        """
+        Return a new ColumnContainer with the
+        given column added.
+        The column is added at the last position in the column list.
+        """
         cc = self._copy()
 
         frontend_column = str(frontend_column)
@@ -71,6 +106,10 @@ class ColumnContainer:
         return cc
 
     def get_backend_by_frontend_index(self, index: int) -> str:
+        """
+        Get back the dask column, which is referenced by the
+        frontend (SQL) column with the given index.
+        """
         frontend_column = self._frontend_columns[index]
         backend_column = self._frontend_backend_mapping[frontend_column]
         return backend_column
@@ -79,9 +118,9 @@ class ColumnContainer:
         """
         Make sure we have unique column names by calling each column
 
-            prefix_number
+            <prefix>_<number>
 
-        where number is the column index.
+        where <number> is the column index.
         """
         return self.rename(
             columns={str(col): f"{prefix}_{i}" for i, col in enumerate(self.columns)}
@@ -89,11 +128,30 @@ class ColumnContainer:
 
 
 class DataContainer:
+    """
+    In SQL, every column operation or reference is done via
+    the column index. Some dask operations, such as grouping,
+    joining or concatenating preserve the columns in a different
+    order than SQL would expect.
+    However, we do not want to change the column data itself
+    all the time (because this would lead to computational overhead),
+    but still would like to keep the columns accessible by name and index.
+    For this, we add an additional `ColumnContainer` to each dataframe,
+    which does all the column mapping between "frontend"
+    (what SQL expects, also in the correct order)
+    and "backend" (what dask has).
+    """
+
     def __init__(self, df: dd.DataFrame, column_container: ColumnContainer):
         self.df = df
         self.column_container = column_container
 
     def assign(self) -> dd.DataFrame:
+        """
+        Combine the column mapping with the actual data and return
+        a dataframe which has the the columns specified in the
+        stored ColumnContainer.
+        """
         df = self.df.assign(
             **{
                 col_from: self.df[col_to]

--- a/dask_sql/physical/rel/base.py
+++ b/dask_sql/physical/rel/base.py
@@ -2,6 +2,8 @@ from typing import Dict, List
 
 import dask.dataframe as dd
 
+from dask_sql.datacontainer import ColumnContainer
+
 
 class BaseRelPlugin:
     """
@@ -22,20 +24,20 @@ class BaseRelPlugin:
 
     @staticmethod
     def fix_column_to_row_type(
-        df: dd.DataFrame, row_type: "org.apache.calcite.rel.type.RelDataType"
-    ) -> dd.DataFrame:
+        cc: ColumnContainer, row_type: "org.apache.calcite.rel.type.RelDataType"
+    ) -> ColumnContainer:
         """
-        Make sure that the given dask dataframe
+        Make sure that the given column container
         has the column names specified by the row type.
         We assume that the column order is already correct
         and will just "blindly" rename the columns.
         """
         field_names = [str(x) for x in row_type.getFieldNames()]
 
-        df = df.rename(columns=dict(zip(df.columns, field_names)))
+        cc = cc.rename(columns=dict(zip(cc.columns, field_names)))
 
         # TODO: We can also check for the types here and do any conversions if needed
-        return df[field_names]
+        return cc.limit_to(field_names)
 
     @staticmethod
     def check_columns_from_row_type(

--- a/dask_sql/physical/rel/base.py
+++ b/dask_sql/physical/rel/base.py
@@ -75,16 +75,3 @@ class BaseRelPlugin:
         from dask_sql.physical.rel.convert import RelConverter
 
         return [RelConverter.convert(input_rel, tables) for input_rel in input_rels]
-
-    @staticmethod
-    def make_unique(df, prefix="col"):
-        """
-        Make sure we have unique column names by calling each column
-
-            prefix_number
-
-        where number is the column index.
-        """
-        return df.rename(
-            columns={col: f"{prefix}_{i}" for i, col in enumerate(df.columns)}
-        )

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -73,9 +73,11 @@ class LogicalAggregatePlugin(BaseRelPlugin):
             group_columns = [additional_column_name]
             additional_column_needed = True
 
+        # If needed, add a column to group by which is
+        # the same for all rows
         if additional_column_needed:
             df = df.assign(**{additional_column_name: 1})
-            cc.add(additional_column_name)
+            cc = cc.add(additional_column_name)
 
         # Now we can perform the aggregates
         df = df.groupby(by=group_columns).agg(aggregations)

--- a/dask_sql/physical/rel/logical/filter.py
+++ b/dask_sql/physical/rel/logical/filter.py
@@ -22,6 +22,8 @@ class LogicalFilterPlugin(BaseRelPlugin):
         df = dc.df
         cc = dc.column_container
 
+        # Every logic is handled in the RexConverter
+        # we just need to apply it here
         condition = rel.getCondition()
         df_condition = RexConverter.convert(condition, dc)
         df = df[df_condition]

--- a/dask_sql/physical/rel/logical/filter.py
+++ b/dask_sql/physical/rel/logical/filter.py
@@ -4,6 +4,7 @@ import dask.dataframe as dd
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rel.base import BaseRelPlugin
+from dask_sql.datacontainer import DataContainer
 
 
 class LogicalFilterPlugin(BaseRelPlugin):
@@ -15,14 +16,15 @@ class LogicalFilterPlugin(BaseRelPlugin):
     class_name = "org.apache.calcite.rel.logical.LogicalFilter"
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
-    ) -> dd.DataFrame:
-        (df,) = self.assert_inputs(rel, 1, tables)
-        self.check_columns_from_row_type(df, rel.getExpectedInputRowType(0))
+        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, DataContainer]
+    ) -> DataContainer:
+        (dc,) = self.assert_inputs(rel, 1, tables)
+        df = dc.df
+        cc = dc.column_container
 
         condition = rel.getCondition()
-        df_condition = RexConverter.convert(condition, df)
+        df_condition = RexConverter.convert(condition, dc)
         df = df[df_condition]
 
-        df = self.fix_column_to_row_type(df, rel.getRowType())
-        return df
+        cc = self.fix_column_to_row_type(cc, rel.getRowType())
+        return DataContainer(df, cc)

--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -132,6 +132,7 @@ class LogicalJoinPlugin(BaseRelPlugin):
                 for from_col, to_col in zip(cc.columns, field_specifications)
             }
         )
+        cc = self.fix_column_to_row_type(cc, rel.getRowType())
         dc = DataContainer(df, cc)
 
         # 7. Last but not least we apply any filters by and-chaining together the filters

--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -8,6 +8,7 @@ import dask.dataframe as dd
 from dask_sql.physical.rex import RexConverter
 from dask_sql.java import get_short_java_class
 from dask_sql.physical.rel.base import BaseRelPlugin
+from dask_sql.datacontainer import DataContainer, ColumnContainer
 
 
 class LogicalJoinPlugin(BaseRelPlugin):
@@ -36,20 +37,28 @@ class LogicalJoinPlugin(BaseRelPlugin):
     }
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
-    ) -> dd.DataFrame:
+        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, DataContainer]
+    ) -> DataContainer:
         # Joining is a bit more complicated, so lets do it in steps:
 
         # 1. We now have two inputs (from left and right), so we fetch them both
-        df_lhs, df_rhs = self.assert_inputs(rel, 2, tables)
+        dc_lhs, dc_rhs = self.assert_inputs(rel, 2, tables)
+        cc_lhs = dc_lhs.column_container
+        cc_rhs = dc_rhs.column_container
 
         # 2. dask's merge will do some smart things with columns, which have the same name
         # on lhs an rhs (which also includes reordering).
         # However, that will confuse our column numbering in SQL.
         # So we make our life easier by converting the column names into unique names
         # We will convert back in the end
-        df_lhs_renamed = self.make_unique(df_lhs, "lhs")
-        df_rhs_renamed = self.make_unique(df_rhs, "rhs")
+        cc_lhs_renamed = cc_lhs.make_unique("lhs")
+        cc_rhs_renamed = cc_rhs.make_unique("rhs")
+
+        dc_lhs_renamed = DataContainer(dc_lhs.df, cc_lhs_renamed)
+        dc_rhs_renamed = DataContainer(dc_rhs.df, cc_rhs_renamed)
+
+        df_lhs_renamed = dc_lhs_renamed.assign()
+        df_rhs_renamed = dc_rhs_renamed.assign()
 
         join_type = rel.getJoinType()
         join_type = self.JOIN_TYPE_MAPPING[str(join_type)]
@@ -70,7 +79,7 @@ class LogicalJoinPlugin(BaseRelPlugin):
         # The given column indices are for the full, merged table which consists
         # of lhs and rhs put side-by-side (in this order)
         # We therefore need to normalize the rhs indices relative to the rhs table.
-        rhs_on = [index - len(df_lhs.columns) for index in rhs_on]
+        rhs_on = [index - len(df_lhs_renamed.columns) for index in rhs_on]
 
         # 4. dask can only merge on the same column names.
         # We therefore create new columns on purpose, which have a distinct name.
@@ -109,21 +118,33 @@ class LogicalJoinPlugin(BaseRelPlugin):
 
         # 6. So the next step is to make sure
         # we have the correct column order (and to remove the temporary join columns)
-        df = df[list(df_lhs_renamed.columns) + list(df_rhs_renamed.columns)]
+        correct_column_order = list(df_lhs_renamed.columns) + list(
+            df_rhs_renamed.columns
+        )
+        cc = ColumnContainer(df.columns).limit_to(correct_column_order)
+
+        # and to rename them like the rel specifies
+        row_type = rel.getRowType()
+        field_specifications = [str(f) for f in row_type.getFieldNames()]
+        cc = cc.rename(
+            {
+                from_col: to_col
+                for from_col, to_col in zip(cc.columns, field_specifications)
+            }
+        )
+        dc = DataContainer(df, cc)
 
         # 7. Last but not least we apply any filters by and-chaining together the filters
         if filter_condition:
             # This line is a bit of code duplication with RexCallPlugin - but I guess it is worth to keep it separate
             filter_condition = reduce(
                 operator.and_,
-                [RexConverter.convert(rex, df) for rex in filter_condition],
+                [RexConverter.convert(rex, dc) for rex in filter_condition],
             )
             df = df[filter_condition]
+            dc = DataContainer(df, cc)
 
-        # Now we go back to the names requested by the rel
-        df = self.fix_column_to_row_type(df, rel.getRowType())
-
-        return df
+        return dc
 
     def _split_join_condition(
         self, join_condition: "org.apache.calcite.rex.RexCall"

--- a/dask_sql/physical/rel/logical/project.py
+++ b/dask_sql/physical/rel/logical/project.py
@@ -4,6 +4,7 @@ import dask.dataframe as dd
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rel.base import BaseRelPlugin
+from dask_sql.datacontainer import DataContainer
 
 
 class LogicalProjectPlugin(BaseRelPlugin):
@@ -19,20 +20,26 @@ class LogicalProjectPlugin(BaseRelPlugin):
         self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
     ) -> dd.DataFrame:
         # Get the input of the previous step
-        (df,) = self.assert_inputs(rel, 1, tables)
+        (dc,) = self.assert_inputs(rel, 1, tables)
 
-        # It is easiest to just replace all columns with the new ones
+        df = dc.df
+        cc = dc.column_container
+
+        # Collect all new columns
         named_projects = rel.getNamedProjects()
 
+        # TODO: we do not need to create a new column if we already have it
         new_columns = {}
         for expr, key in named_projects:
-            new_columns[str(key)] = RexConverter.convert(expr, df)
+            new_columns[str(key)] = RexConverter.convert(expr, dc=dc)
 
-        df = df.drop(columns=list(df.columns)).assign(**new_columns)
+        df = df.assign(**new_columns)
+        for new_column in new_columns:
+            cc = cc.add(new_column)
 
         # Make sure the order is correct
         column_names = list(new_columns.keys())
-        df = df[column_names]
+        cc = cc.limit_to(column_names)
 
-        df = self.fix_column_to_row_type(df, rel.getRowType())
-        return df
+        cc = self.fix_column_to_row_type(cc, rel.getRowType())
+        return DataContainer(df, cc)

--- a/dask_sql/physical/rel/logical/sort.py
+++ b/dask_sql/physical/rel/logical/sort.py
@@ -50,6 +50,7 @@ class LogicalSortPlugin(BaseRelPlugin):
         if offset is not None or end is not None:
             df = self._apply_offset(df, offset, end)
 
+        cc = self.fix_column_to_row_type(cc, rel.getRowType())
         return DataContainer(df, cc)
 
     def _apply_sort(

--- a/dask_sql/physical/rel/logical/union.py
+++ b/dask_sql/physical/rel/logical/union.py
@@ -4,6 +4,7 @@ import dask.dataframe as dd
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rel.base import BaseRelPlugin
+from dask_sql.datacontainer import DataContainer, ColumnContainer
 
 
 class LogicalUnionPlugin(BaseRelPlugin):
@@ -15,26 +16,42 @@ class LogicalUnionPlugin(BaseRelPlugin):
     class_name = "org.apache.calcite.rel.logical.LogicalUnion"
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
-    ) -> dd.DataFrame:
-        first_df, second_df = self.assert_inputs(rel, 2, tables)
+        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, DataContainer]
+    ) -> DataContainer:
+        first_dc, second_dc = self.assert_inputs(rel, 2, tables)
+
+        first_df = first_dc.df
+        first_cc = first_dc.column_container
+
+        second_df = second_dc.df
+        second_cc = second_dc.column_container
 
         # For concatenating, they should have exactly the same fields
         output_field_names = [str(x) for x in rel.getRowType().getFieldNames()]
-        assert len(first_df.columns) == len(output_field_names)
-        first_df = first_df.rename(
+        assert len(first_cc.columns) == len(output_field_names)
+        first_cc = first_cc.rename(
             columns={
                 col: output_col
-                for col, output_col in zip(first_df.columns, output_field_names)
+                for col, output_col in zip(first_cc.columns, output_field_names)
             }
         )
-        assert len(second_df.columns) == len(output_field_names)
-        second_df = second_df.rename(
+        first_dc = DataContainer(first_df, first_cc)
+
+        assert len(second_cc.columns) == len(output_field_names)
+        second_cc = second_cc.rename(
             columns={
                 col: output_col
-                for col, output_col in zip(second_df.columns, output_field_names)
+                for col, output_col in zip(second_cc.columns, output_field_names)
             }
         )
+        second_dc = DataContainer(second_df, second_cc)
+
+        # To concat the to dataframes, we need to make sure the
+        # columns actually have the specified names in the
+        # column containers
+        # Otherwise the concat won't work
+        first_df = first_dc.assign()
+        second_df = second_dc.assign()
 
         self.check_columns_from_row_type(first_df, rel.getExpectedInputRowType(0))
         self.check_columns_from_row_type(second_df, rel.getExpectedInputRowType(1))
@@ -44,5 +61,6 @@ class LogicalUnionPlugin(BaseRelPlugin):
         if not rel.all:
             df = df.drop_duplicates()
 
-        df = self.fix_column_to_row_type(df, rel.getRowType())
-        return df
+        cc = ColumnContainer(df.columns)
+        cc = self.fix_column_to_row_type(cc, rel.getRowType())
+        return DataContainer(df, cc)

--- a/dask_sql/physical/rel/logical/values.py
+++ b/dask_sql/physical/rel/logical/values.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rel.base import BaseRelPlugin
+from dask_sql.datacontainer import DataContainer, ColumnContainer
 
 
 class LogicalValuesPlugin(BaseRelPlugin):
@@ -24,8 +25,8 @@ class LogicalValuesPlugin(BaseRelPlugin):
     class_name = "org.apache.calcite.rel.logical.LogicalValues"
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
-    ) -> dd.DataFrame:
+        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, DataContainer]
+    ) -> DataContainer:
         # There should not be any input. This is the first step.
         self.assert_inputs(rel, 0)
 
@@ -37,6 +38,6 @@ class LogicalValuesPlugin(BaseRelPlugin):
         # We assume here that when using the values plan, the resulting dataframe will be quite small
         # TODO: we explicitely reference pandas and dask here -> might we worth making this more general
         df = dd.from_pandas(pd.DataFrame(rows), npartitions=1)
-        df = self.fix_column_to_row_type(df, rel.getRowType())
+        cc = ColumnContainer(df.columns)
 
-        return df
+        return DataContainer(df, cc)

--- a/dask_sql/physical/rel/logical/values.py
+++ b/dask_sql/physical/rel/logical/values.py
@@ -32,12 +32,23 @@ class LogicalValuesPlugin(BaseRelPlugin):
 
         rex_expression_rows = list(rel.getTuples())
         rows = []
-        for rex_expressions in rex_expression_rows:
-            rows.append([RexConverter.convert(rex, None) for rex in rex_expressions])
+        for rex_expression_row in rex_expression_rows:
+            # We convert each of the cells in the row
+            # using a RexConverter.
+            # As we do not have any information on the
+            # column headers, we just name them with
+            # their index.
+            rows.append(
+                {
+                    str(i): RexConverter.convert(rex_cell, None)
+                    for i, rex_cell in enumerate(rex_expression_row)
+                }
+            )
 
-        # We assume here that when using the values plan, the resulting dataframe will be quite small
         # TODO: we explicitely reference pandas and dask here -> might we worth making this more general
-        df = dd.from_pandas(pd.DataFrame(rows), npartitions=1)
+        # We assume here that when using the values plan, the resulting dataframe will be quite small
+        df = pd.DataFrame(rows)
+        df = dd.from_pandas(df, npartitions=1)
         cc = ColumnContainer(df.columns)
 
         return DataContainer(df, cc)

--- a/dask_sql/physical/rel/logical/values.py
+++ b/dask_sql/physical/rel/logical/values.py
@@ -51,4 +51,5 @@ class LogicalValuesPlugin(BaseRelPlugin):
         df = dd.from_pandas(df, npartitions=1)
         cc = ColumnContainer(df.columns)
 
+        cc = self.fix_column_to_row_type(cc, rel.getRowType())
         return DataContainer(df, cc)

--- a/dask_sql/physical/rex/base.py
+++ b/dask_sql/physical/rex/base.py
@@ -2,6 +2,8 @@ from typing import Union, Any
 
 import dask.dataframe as dd
 
+from dask_sql.datacontainer import DataContainer
+
 
 class BaseRexPlugin:
     """
@@ -15,7 +17,7 @@ class BaseRexPlugin:
     class_name = None
 
     def convert(
-        self, rex: "org.apache.calcite.rex.RexNode", df: dd.DataFrame
+        self, rex: "org.apache.calcite.rex.RexNode", dc: DataContainer
     ) -> Union[dd.Series, Any]:
         """Base method to implement"""
         raise NotImplementedError  # pragma: no cover

--- a/dask_sql/physical/rex/convert.py
+++ b/dask_sql/physical/rex/convert.py
@@ -5,6 +5,7 @@ import dask.dataframe as dd
 from dask_sql.java import get_java_class
 from dask_sql.utils import Pluggable
 from dask_sql.physical.rex.base import BaseRexPlugin
+from dask_sql.datacontainer import DataContainer
 
 
 class RexConverter(Pluggable):
@@ -30,8 +31,8 @@ class RexConverter(Pluggable):
 
     @classmethod
     def convert(
-        cls, rex: "org.apache.calcite.rex.RexNode", df: dd.DataFrame
-    ) -> Union[dd.DataFrame, Any]:
+        cls, rex: "org.apache.calcite.rex.RexNode", dc: DataContainer
+    ) -> Union[dd.Series, Any]:
         """
         Convert the given rel (java instance)
         into a python expression (a dask dataframe)
@@ -47,5 +48,5 @@ class RexConverter(Pluggable):
                 f"No conversion for class {class_name} available (yet)."
             )
 
-        df = plugin_instance.convert(rex, df=df)
+        df = plugin_instance.convert(rex, dc=dc)
         return df

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -9,6 +9,7 @@ import dask.dataframe as dd
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.utils import is_frame
+from dask_sql.datacontainer import DataContainer
 
 
 class Operation:
@@ -182,10 +183,10 @@ class RexCallPlugin:
     }
 
     def convert(
-        self, rex: "org.apache.calcite.rex.RexNode", df: dd.DataFrame
+        self, rex: "org.apache.calcite.rex.RexNode", dc: DataContainer
     ) -> Union[dd.Series, Any]:
         # Prepare the operands by turning the RexNodes into python expressions
-        operands = [RexConverter.convert(o, df) for o in rex.getOperands()]
+        operands = [RexConverter.convert(o, dc) for o in rex.getOperands()]
 
         # Now use the operator name in the mapping
         operator_name = str(rex.getOperator().getName())

--- a/dask_sql/physical/rex/core/input_ref.py
+++ b/dask_sql/physical/rex/core/input_ref.py
@@ -1,6 +1,7 @@
 import dask.dataframe as dd
 
 from dask_sql.physical.rex.base import BaseRexPlugin
+from dask_sql.datacontainer import DataContainer
 
 
 class RexInputRefPlugin(BaseRexPlugin):
@@ -13,8 +14,12 @@ class RexInputRefPlugin(BaseRexPlugin):
     class_name = "org.apache.calcite.rex.RexInputRef"
 
     def convert(
-        self, rex: "org.apache.calcite.rex.RexNode", df: dd.DataFrame
+        self, rex: "org.apache.calcite.rex.RexNode", dc: DataContainer
     ) -> dd.Series:
+        df = dc.df
+        cc = dc.column_container
+
         # The column is references by index
         index = rex.getIndex()
-        return df.iloc[:, index]
+        backend_column_name = cc.get_backend_by_frontend_index(index)
+        return df[backend_column_name]

--- a/dask_sql/physical/rex/core/literal.py
+++ b/dask_sql/physical/rex/core/literal.py
@@ -1,9 +1,11 @@
 from typing import Any
 
+import numpy as np
 import dask.dataframe as dd
 
 from dask_sql.physical.rex.base import BaseRexPlugin
 from dask_sql.mappings import sql_to_python_type, null_python_type
+from dask_sql.datacontainer import DataContainer
 
 
 class RexLiteralPlugin(BaseRexPlugin):
@@ -18,7 +20,7 @@ class RexLiteralPlugin(BaseRexPlugin):
 
     class_name = "org.apache.calcite.rex.RexLiteral"
 
-    def convert(self, rex: "org.apache.calcite.rex.RexNode", df: dd.DataFrame) -> Any:
+    def convert(self, rex: "org.apache.calcite.rex.RexNode", dc: DataContainer) -> Any:
         literal_type = str(rex.getType())
         python_type = sql_to_python_type(literal_type)
 

--- a/tests/integration/test_select.py
+++ b/tests/integration/test_select.py
@@ -13,6 +13,15 @@ class SelectTestCase(DaskTestCase):
 
         assert_frame_equal(df, self.df)
 
+    def test_select_alias(self):
+        df = self.c.sql("SELECT a as b, b as a FROM df")
+        df = df.compute()
+
+        expected_df = self.df
+        expected_df.assign(a=self.df.b, b=self.df.a)
+
+        assert_frame_equal(df, expected_df)
+
     def test_select_column(self):
         df = self.c.sql("SELECT a FROM df")
         df = df.compute()


### PR DESCRIPTION
Currently, a lot of dask computation is spent in renaming or assigning new columns instead of the "real" calculation, as - to be consistent with what the Relational Algebra gives to us - the columns of the intermediate dataframes are renamed quite often.

This WIP PR includes a new data type, which contains the real data as well as a frontend column mapping. Typically, physical plans will only operate on the data itself and do not care so much about the column names, so we can store the columns separately to the real data.

In my very small tests, this brings dask-sql approximately en-par with usual dask calls in simple cases, such as 
```sql
SELECT a, MAX(b) FROM df
```

The PR still needs documentation and more unittests for the new classes.