### PR TITLE
Added nicer error messages on parsing failures

### DIFF
--- a/dask_sql/java.py
+++ b/dask_sql/java.py
@@ -36,6 +36,8 @@ RelationalAlgebraGenerator = jpype.JClass(
 )
 SqlTypeName = jpype.JClass("org.apache.calcite.sql.type.SqlTypeName")
 List = jpype.JClass("java.util.List")
+ValidationException = jpype.JClass("org.apache.calcite.tools.ValidationException")
+SqlParseException = jpype.JClass("org.apache.calcite.sql.parser.SqlParseException")
 
 
 def get_java_class(instance):

--- a/dask_sql/utils.py
+++ b/dask_sql/utils.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import re
 
 import numpy as np
 
@@ -33,3 +34,91 @@ class Pluggable:
     def get_plugin(cls, name):
         """Get a plugin with the given name"""
         return Pluggable.__plugins[cls][name]
+
+
+class ParsingException(Exception):
+    """
+    Helper class to format validation and parsing SQL
+    exception in a nicer way
+    """
+
+    JAVA_MSG_REGEX = "^.*?line (?P<from_line>\d+), column (?P<from_col>\d+)"
+    JAVA_MSG_REGEX += "(?: to line (?P<to_line>\d+), column (?P<to_col>\d+))?"
+
+    def __init__(self, sql, validation_exception_string):
+        """
+        Create a new exception out of the SQL query and the exception text
+        raise by calcite.
+        """
+        message = self._extract_message(sql, validation_exception_string)
+        super().__init__(message)
+
+    @staticmethod
+    def _line_with_marker(line, marker_from=0, marker_to=None):
+        """
+        Add ^ markers under the line specified by the parameters.
+        """
+        if not marker_to:
+            marker_to = len(line)
+
+        return [line] + [" " * marker_from + "^" * (marker_to - marker_from + 1)]
+
+    def _extract_message(self, sql, validation_exception_string):
+        """
+        Produce a human-readable error message
+        out of the Java error message by extracting the column
+        and line statements and marking the SQL code with ^ below.
+
+        Typical error message look like:
+            org.apache.calcite.runtime.CalciteContextException: From line 3, column 12 to line 3, column 16: Column 'test' not found in any table
+            Lexical error at line 4, column 15.  Encountered: "\n" (10), after : "`Te"
+        """
+        message = validation_exception_string.strip()
+
+        match = re.match(self.JAVA_MSG_REGEX, message)
+        if not match:
+            # Don't understand this message - just return it
+            return message
+
+        match = match.groupdict()
+
+        from_line = int(match["from_line"]) - 1
+        from_col = int(match["from_col"]) - 1
+        to_line = int(match["to_line"]) - 1 if match["to_line"] else None
+        to_col = int(match["to_col"]) - 1 if match["to_col"] else None
+
+        # Add line markings below the sql code
+        sql = sql.splitlines()
+
+        if from_line == to_line:
+            sql = (
+                sql[:from_line]
+                + self._line_with_marker(sql[from_line], from_col, to_col)
+                + sql[from_line + 1 :]
+            )
+        elif to_line is None:
+            sql = (
+                sql[:from_line]
+                + self._line_with_marker(sql[from_line], from_col, from_col)
+                + sql[from_line + 1 :]
+            )
+        else:
+            sql = (
+                sql[:from_line]
+                + self._line_with_marker(sql[from_line], from_col)
+                + sum(
+                    [
+                        self._line_with_marker(sql[line])
+                        for line in range(from_line + 1, to_line)
+                    ],
+                    [],
+                )
+                + self._line_with_marker(sql[to_line], 0, to_col)
+                + sql[to_line + 1 :]
+            )
+
+        message = f"Can not parse the given SQL: {message}\n\n"
+        message += "The problem is probably somewhere here:\n"
+        message += "\n\t" + "\n\t".join(sql)
+
+        return message

--- a/tests/integration/test_select.py
+++ b/tests/integration/test_select.py
@@ -3,6 +3,7 @@ import pandas as pd
 from pandas.testing import assert_frame_equal
 import dask.dataframe as dd
 
+from dask_sql.utils import ParsingException
 from tests.integration.fixtures import DaskTestCase
 
 
@@ -65,3 +66,9 @@ class SelectTestCase(DaskTestCase):
             {"e": 2 * (self.df["a"] - 1), "f": 2 * self.df["b"] - 1}
         )
         assert_frame_equal(df, expected_df)
+
+    def test_wrong_input(self):
+        self.assertRaises(ParsingException, self.c.sql, """SELECT x FROM df""")
+        self.assertRaises(
+            ParsingException, self.c.sql, """SELECT x FROM df""", debug=True
+        )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 from dask import dataframe as dd
 import pandas as pd
 
-from dask_sql.utils import is_frame, Pluggable
+from dask_sql.utils import is_frame, Pluggable, ParsingException
 
 
 def test_is_frame_for_frame():
@@ -52,3 +52,50 @@ def test_overwrite():
 
     assert PluginTest1.get_plugin("some_key") == "value_2"
     assert PluginTest1().get_plugin("some_key") == "value_2"
+
+
+def test_exception_parsing():
+    e = ParsingException(
+        "SELECT * FROM df",
+        """org.apache.calcite.runtime.CalciteContextException: From line 1, column 3 to line 1, column 4: Message""",
+    )
+
+    expected = """Can not parse the given SQL: org.apache.calcite.runtime.CalciteContextException: From line 1, column 3 to line 1, column 4: Message
+
+The problem is probably somewhere here:
+
+\tSELECT * FROM df
+\t  ^^"""
+    assert str(e) == expected
+
+    e = ParsingException(
+        "SELECT * FROM df", """Lexical error at line 1, column 3.  Message""",
+    )
+
+    expected = """Can not parse the given SQL: Lexical error at line 1, column 3.  Message
+
+The problem is probably somewhere here:
+
+\tSELECT * FROM df
+\t  ^"""
+    assert str(e) == expected
+
+    e = ParsingException(
+        "SELECT *\nFROM df\nWHERE x = 3",
+        """From line 1, column 3 to line 2, column 3: Message""",
+    )
+
+    expected = """Can not parse the given SQL: From line 1, column 3 to line 2, column 3: Message
+
+The problem is probably somewhere here:
+
+\tSELECT *
+\t  ^^^^^^^
+\tFROM df
+\t^^^
+\tWHERE x = 3"""
+    assert str(e) == expected
+
+    e = ParsingException("SELECT *", "Message",)
+
+    assert str(e) == "Message"


### PR DESCRIPTION
Fixes #4 

Instead of showing all the traceback from calcite (java) -> jpype -> python we only show a single, hand-made exception now, which gives information on the parsing error and where it happened.

For the example given in the issue #4, this would now look like

```
Traceback (most recent call last):
  File "test_me.py", line 7, in <module>
    context.sql("SELECT * from timeseries where name=Tim")
  File "/home/nils/projects/private/dask-sql/dask_sql/context.py", line 92, in sql
    raise ParsingException(sql, str(e.message())) from from_chained_exception
dask_sql.utils.ParsingException: Can not parse the given SQL: org.apache.calcite.runtime.CalciteContextException: From line 1, column 37 to line 1, column 39: Column 'Tim' not found in any table

The problem is probably somewhere here:

        SELECT * from timeseries where name=Tim
                                            ^^^
```

I took the idea to show ^ indicators from clang and blazingSQL.