### PR TITLE
Use human-readable columns instead if `EXPR$`

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -93,8 +93,12 @@ class Context:
         # Now create a relational algebra from that
         generator = RelationalAlgebraGenerator(schema)
 
-        rel = generator.getRelationalAlgebra(sql)
-        if debug:  # pragma: no cover
+        sqlNode = generator.getSqlNode(sql)
+        validatedSqlNode = generator.getValidatedNode(sqlNode)
+        nonOptimizedRelNode = generator.getRelationalAlgebra(validatedSqlNode)
+        rel = generator.getOptimizedRelationalAlgebra(nonOptimizedRelNode)
+
+        if debug:
             print(generator.getRelationalAlgebraString(rel))
 
         return rel

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -47,10 +47,14 @@ class GroupbyTestCase(DaskTestCase):
         )
         df = df.compute()
 
-        expected_df = pd.DataFrame({"EXPR$0": [2, 3, 4], "S": [1, 1, 1]})
-        expected_df["EXPR$0"] = expected_df["EXPR$0"].astype("int64")
+        user_id_column = '"user_table_1"."user_id" + 1'
+
+        expected_df = pd.DataFrame({user_id_column: [2, 3, 4], "S": [1, 1, 1]})
+        expected_df[user_id_column] = expected_df[user_id_column].astype("int64")
         expected_df["S"] = expected_df["S"].astype("float64")
-        assert_frame_equal(df.sort_values("EXPR$0").reset_index(drop=True), expected_df)
+        assert_frame_equal(
+            df.sort_values(user_id_column).reset_index(drop=True), expected_df
+        )
 
     def test_group_by_nan(self):
         df = self.c.sql(

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -9,7 +9,7 @@ class GroupbyTestCase(DaskTestCase):
         df = self.c.sql(
             """
         SELECT
-            user_id, SUM(b) AS S
+            user_id, SUM(b) AS "S"
         FROM user_table_1
         GROUP BY user_id
         """
@@ -25,7 +25,7 @@ class GroupbyTestCase(DaskTestCase):
         df = self.c.sql(
             """
         SELECT
-            SUM(b) AS S, SUM(2) AS X
+            SUM(b) AS "S", SUM(2) AS "X"
         FROM user_table_1
         """
         )
@@ -40,7 +40,7 @@ class GroupbyTestCase(DaskTestCase):
         df = self.c.sql(
             """
         SELECT
-            user_id + 1, SUM(CASE WHEN b = 3 THEN 1 END) AS S
+            user_id + 1, SUM(CASE WHEN b = 3 THEN 1 END) AS "S"
         FROM user_table_1
         GROUP BY user_id + 1
         """

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -11,10 +11,10 @@ class RexOperationsTestCase(DaskTestCase):
         df = self.c.sql(
             """
         SELECT
-            (CASE WHEN a = 3 THEN 1 END) AS S1,
-            (CASE WHEN a > 0 THEN a ELSE 1 END) AS S2,
-            (CASE WHEN a = 4 THEN 3 ELSE a + 1 END) AS S3,
-            (CASE WHEN a = 3 THEN 1 ELSE a END) AS S4
+            (CASE WHEN a = 3 THEN 1 END) AS "S1",
+            (CASE WHEN a > 0 THEN a ELSE 1 END) AS "S2",
+            (CASE WHEN a = 4 THEN 3 ELSE a + 1 END) AS "S3",
+            (CASE WHEN a = 3 THEN 1 ELSE a END) AS "S4"
         FROM df
         """
         )
@@ -29,12 +29,12 @@ class RexOperationsTestCase(DaskTestCase):
 
     def test_literals(self):
         df = self.c.sql(
-            """SELECT 'a string äö' AS S,
-                      4.4 AS F,
-                      -4564347464 AS I,
-                      TIME '08:08:00.091' AS T,
-                      TIMESTAMP '2022-04-06 17:33:21' AS DT,
-                      DATE '1991-06-02' AS D
+            """SELECT 'a string äö' AS "S",
+                      4.4 AS "F",
+                      -4564347464 AS "I",
+                      TIME '08:08:00.091' AS "T",
+                      TIMESTAMP '2022-04-06 17:33:21' AS "DT",
+                      DATE '1991-06-02' AS "D"
             """
         )
         df = df.compute()
@@ -52,7 +52,11 @@ class RexOperationsTestCase(DaskTestCase):
         assert_frame_equal(df, expected_df)
 
     def test_literal_null(self):
-        df = self.c.sql("""SELECT NULL AS N, 1 + NULL AS I""")
+        df = self.c.sql(
+            """
+        SELECT NULL AS "N", 1 + NULL AS "I"
+        """
+        )
         df = df.compute()
 
         expected_df = pd.DataFrame({"N": [None], "I": [np.nan]})

--- a/tests/integration/test_select.py
+++ b/tests/integration/test_select.py
@@ -42,10 +42,16 @@ class SelectTestCase(DaskTestCase):
         assert_frame_equal(df, expected_df)
 
     def test_select_expr(self):
-        df = self.c.sql("SELECT a + 1 AS a, b AS bla FROM df")
+        df = self.c.sql("SELECT a + 1 AS a, b AS bla, a - 1 FROM df")
         df = df.compute()
 
-        expected_df = pd.DataFrame({"a": self.df["a"] + 1, "bla": self.df["b"]})
+        expected_df = pd.DataFrame(
+            {
+                "a": self.df["a"] + 1,
+                "bla": self.df["b"],
+                '"df"."a" - 1': self.df["a"] - 1,
+            }
+        )
         assert_frame_equal(df, expected_df)
 
     def test_select_of_select(self):

--- a/tests/integration/test_select.py
+++ b/tests/integration/test_select.py
@@ -56,7 +56,7 @@ class SelectTestCase(DaskTestCase):
             (
                 SELECT a - 1 AS c, 2*b  AS d
                 FROM df
-            ) AS `inner`
+            ) AS "inner"
             """
         )
         df = df.compute()

--- a/tests/integration/test_union.py
+++ b/tests/integration/test_union.py
@@ -37,9 +37,9 @@ class UnionTestCase(DaskTestCase):
     def test_union_mixed(self):
         df = self.c.sql(
             """
-            SELECT a AS I, b as II FROM df
+            SELECT a AS "I", b as "II" FROM df
             UNION ALL
-            SELECT a as I, a as II FROM long_table
+            SELECT a as "I", a as "II" FROM long_table
             """
         )
         df = df.compute()


### PR DESCRIPTION
Fixes #27.

Newly created columns in Apache Calcite are named `EXPR$N` where N is a number.
These column names are not very helpful for the user, as correctly described in #27.
This PR introduces two changes:
* use the postgres dialect everywhere for parsing (before, everything but the quoting was postgres - that was a mistake), but if we correctly want to convert back to an SQL string we should have a consistent dialect
* replace EXPR$ columns in the final output with more meaningful names, by re-converting the SQL column specification into a string.

In the example given in the issue

```python
import dask
import dask_sql
context = dask_sql.Context()
df = dask.datasets.timeseries()
context.register_dask_table(df, "timeseries")
context.sql("SELECT sum(x), sum(y) from timeseries").compute()
```

this would now give

```
   SUM("timeseries"."x")  SUM("timeseries"."y")
0            -553.574597              423.93278
```