### PR TITLE
Increase coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,20 @@
+[run]
+omit = tests/*
+       dask_sql/server/*
+branch = True
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 addopts =
-    --cov dask_sql
+    --cov dask_sql --cov-config=.coveragerc
 testpaths =
     tests

--- a/tests/integration/test_join.py
+++ b/tests/integration/test_join.py
@@ -105,6 +105,31 @@ class JoinTestCase(DaskTestCase):
             df.sort_values(["a", "b"]).reset_index(drop=True), df_expected
         )
 
+        df = self.c.sql(
+            """
+                SELECT lhs.a, lhs.b, rhs.a, rhs.b
+                FROM
+                    df_simple AS lhs
+                JOIN df_simple AS rhs
+                ON lhs.a < rhs.b AND lhs.b < rhs.a
+            """,
+            debug=True,
+        )
+        df = df.compute()
+
+        df_expected = pd.DataFrame(
+            {
+                "a": [1, 1, 2],
+                "b": [1.1, 1.1, 2.2],
+                "a0": [2, 3, 3],
+                "b0": [2.2, 3.3, 3.3],
+            }
+        )
+
+        assert_frame_equal(
+            df.sort_values(["a", "b0"]).reset_index(drop=True), df_expected
+        )
+
     def test_join_complex_2(self):
         df = self.c.sql(
             """


### PR DESCRIPTION
Currently, the SQL server is only a development feature, so it makes no sense to include it into the coverage counting.
Following the principle of ["broken windows"](https://en.wikipedia.org/wiki/Broken_windows_theory) lets try to keep the coverage at 100% all the time.