### PR TITLE
Custom functions

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -1,16 +1,25 @@
+from typing import Callable, List, Tuple
+from collections import namedtuple
+
 import dask.dataframe as dd
 
 from dask_sql.java import (
+    DaskAggregateFunction,
+    DaskScalarFunction,
     DaskSchema,
     DaskTable,
     RelationalAlgebraGenerator,
-    ValidationException,
     SqlParseException,
+    ValidationException,
 )
 from dask_sql.mappings import python_to_sql_type
 from dask_sql.physical.rel import RelConverter, logical
 from dask_sql.physical.rex import RexConverter, core
 from dask_sql.utils import ParsingException
+
+FunctionDescription = namedtuple(
+    "FunctionDescription", ["f", "parameters", "return_type", "aggregation"]
+)
 
 
 class Context:
@@ -44,6 +53,10 @@ class Context:
         """
         # Storage for the registered tables
         self.tables = {}
+        # Storage for the registered functions
+        self.functions = {}
+        # Storage for the registered aggregations
+        self.aggregations = {}
 
         # Register any default plugins, if nothing was registered before.
         RelConverter.add_plugin_class(logical.LogicalAggregatePlugin, replace=False)
@@ -67,7 +80,82 @@ class Context:
         Please note, that the table is stored as it is now.
         If you change the table later, you need to re-register.
         """
-        self.tables[name] = df.copy()
+        self.tables[name.lower()] = df.copy()
+
+    def register_function(
+        self,
+        f: Callable,
+        name: str,
+        parameters: List[Tuple[str, type]],
+        return_type: type,
+    ):
+        """
+        Register a custom function with the given name.
+        The function can be used (with this name)
+        in every SQL queries from now on - but only for scalar operations
+        (no aggregations).
+        This means, if you register a function "f", you can now call
+
+            SELECT f(x)
+            FROM df
+
+        Please note that you can always only have one function with the same name;
+        no matter if it is an aggregation or scalar function.
+
+        For the registration, you need to supply both the
+        list of parameter and parameter types as well as the
+        return type. Use numpy dtypes if possible.
+        Example:
+
+            def f(x):
+                return x ** 2
+
+            c.register_function(f, "f", [("x", np.int64)], np.int64)
+
+            sql = "SELECT f(x) FROM df"
+            df_result = c.sql(sql)
+
+        """
+        self.functions[name.lower()] = FunctionDescription(
+            f, parameters, return_type, False
+        )
+
+    def register_aggregation(
+        self,
+        f: dd.Aggregation,
+        name: str,
+        parameters: List[Tuple[str, type]],
+        return_type: type,
+    ):
+        """
+        Register a custom aggregation with the given name.
+        The aggregation can be used (with this name)
+        in every SQL queries from now on - but only for aggregation operations
+        (no scalar function calls).
+        This means, if you register a aggregation "fagg", you can now call
+
+            SELECT fagg(y)
+            FROM df
+            GROUP BY x
+
+        Please note that you can always only have one function with the same name;
+        no matter if it is an aggregation or scalar function.
+
+        For the registration, you need to supply both the
+        list of parameter and parameter types as well as the
+        return type. Use numpy dtypes if possible.
+        Example:
+
+            fagg = dd.Aggregation("fagg", lambda x: x.sum(), lambda x: x.sum())
+            c.register_aggregation(fagg, "fagg", [("x", np.float64)], np.float64)
+
+            sql = "SELECT fagg(y) FROM df GROUP BY x"
+            df_result = c.sql(sql)
+
+        """
+        self.functions[name.lower()] = FunctionDescription(
+            f, parameters, return_type, True
+        )
 
     def sql(self, sql: str, debug: bool = False) -> dd.DataFrame:
         """
@@ -78,7 +166,7 @@ class Context:
         """
         try:
             rel = self._get_ral(sql, debug=debug)
-            df = RelConverter.convert(rel, tables=self.tables)
+            df = RelConverter.convert(rel, context=self)
         except (ValidationException, SqlParseException) as e:
             if debug:
                 from_chained_exception = e
@@ -92,21 +180,47 @@ class Context:
             raise ParsingException(sql, str(e.message())) from from_chained_exception
         return df
 
-    def _get_ral(self, sql, debug: bool = False):
-        """Helper function to turn the sql query into a relational algebra"""
-        # Create a schema filled with the dataframes we have
-        # currently in our list
+    def _prepare_schema(self):
+        """
+        Create a schema filled with the dataframes
+        and functions we have currently in our list
+        """
         schema = DaskSchema("schema")
 
         for name, df in self.tables.items():
             table = DaskTable(name)
-            for order, column in enumerate(df.columns):
+            for column in df.columns:
                 data_type = df[column].dtype
                 sql_data_type = python_to_sql_type(data_type)
 
                 table.addColumn(column, sql_data_type)
 
             schema.addTable(table)
+
+        for name, function_description in self.functions.items():
+            sql_return_type = python_to_sql_type(function_description.return_type)
+            if function_description.aggregation:
+                dask_function = DaskAggregateFunction(name, sql_return_type)
+            else:
+                dask_function = DaskScalarFunction(name, sql_return_type)
+            self._add_parameters_from_description(function_description, dask_function)
+
+            schema.addFunction(dask_function)
+
+        return schema
+
+    @staticmethod
+    def _add_parameters_from_description(function_description, dask_function):
+        for parameter in function_description.parameters:
+            param_name, param_type = parameter
+            sql_param_type = python_to_sql_type(param_type)
+
+            dask_function.addParameter(param_name, sql_param_type, False)
+
+    def _get_ral(self, sql, debug: bool = False):
+        """Helper function to turn the sql query into a relational algebra"""
+        # get the schema of what we currently have registered
+        schema = self._prepare_schema()
 
         # Now create a relational algebra from that
         generator = RelationalAlgebraGenerator(schema)

--- a/dask_sql/java.py
+++ b/dask_sql/java.py
@@ -30,6 +30,8 @@ jpype.startJVM(
 
 # Some Java classes we need
 DaskTable = jpype.JClass("com.dask.sql.schema.DaskTable")
+DaskAggregateFunction = jpype.JClass("com.dask.sql.schema.DaskAggregateFunction")
+DaskScalarFunction = jpype.JClass("com.dask.sql.schema.DaskScalarFunction")
 DaskSchema = jpype.JClass("com.dask.sql.schema.DaskSchema")
 RelationalAlgebraGenerator = jpype.JClass(
     "com.dask.sql.application.RelationalAlgebraGenerator"

--- a/dask_sql/mappings.py
+++ b/dask_sql/mappings.py
@@ -40,8 +40,11 @@ _SQL_TO_PYTHON = {
 def python_to_sql_type(python_type):
     """Mapping between python and SQL types."""
 
+    if isinstance(python_type, np.dtype):
+        python_type = python_type.type
+
     try:
-        return _PYTHON_TO_SQL[python_type.type]
+        return _PYTHON_TO_SQL[python_type]
     except KeyError:  # pragma: no cover
         raise NotImplementedError(
             f"The python type {python_type} is not implemented (yet)"

--- a/dask_sql/physical/rel/base.py
+++ b/dask_sql/physical/rel/base.py
@@ -15,7 +15,7 @@ class BaseRelPlugin:
     class_name = None
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
+        self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
     ) -> dd.DataFrame:
         """Base method to implement"""
         raise NotImplementedError  # pragma: no cover
@@ -56,7 +56,7 @@ class BaseRelPlugin:
     def assert_inputs(
         rel: "org.apache.calcite.rel.RelNode",
         n: int = 1,
-        tables: Dict[str, dd.DataFrame] = None,
+        context: "dask_sql.Context" = None,
     ) -> List[dd.DataFrame]:
         """
         Many RelNodes build on top of others.
@@ -72,7 +72,7 @@ class BaseRelPlugin:
         # Late import to remove cycling dependency
         from dask_sql.physical.rel.convert import RelConverter
 
-        return [RelConverter.convert(input_rel, tables) for input_rel in input_rels]
+        return [RelConverter.convert(input_rel, context) for input_rel in input_rels]
 
     @staticmethod
     def make_unique(df, prefix="col"):

--- a/dask_sql/physical/rel/convert.py
+++ b/dask_sql/physical/rel/convert.py
@@ -18,7 +18,7 @@ class RelConverter(Pluggable):
     and they are expected to have a convert (instance) method
     in the form
 
-        def convert(self, rel, tables)
+        def convert(self, rel, context)
 
     to do the actual conversion.
     """
@@ -30,13 +30,13 @@ class RelConverter(Pluggable):
 
     @classmethod
     def convert(
-        cls, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
+        cls, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
     ) -> dd.DataFrame:
         """
         Convert the given rel (java instance)
         into a python expression (a dask dataframe)
         using the stored plugins and the dictionary of
-        registered dask tables.
+        registered dask tables from the context.
         """
         class_name = get_java_class(rel)
 
@@ -47,5 +47,5 @@ class RelConverter(Pluggable):
                 f"No conversion for class {class_name} available (yet)."
             )
 
-        df = plugin_instance.convert(rel, tables=tables)
+        df = plugin_instance.convert(rel, context=context)
         return df

--- a/dask_sql/physical/rel/logical/filter.py
+++ b/dask_sql/physical/rel/logical/filter.py
@@ -15,13 +15,13 @@ class LogicalFilterPlugin(BaseRelPlugin):
     class_name = "org.apache.calcite.rel.logical.LogicalFilter"
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
+        self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
     ) -> dd.DataFrame:
-        (df,) = self.assert_inputs(rel, 1, tables)
+        (df,) = self.assert_inputs(rel, 1, context)
         self.check_columns_from_row_type(df, rel.getExpectedInputRowType(0))
 
         condition = rel.getCondition()
-        df_condition = RexConverter.convert(condition, df)
+        df_condition = RexConverter.convert(condition, df, context=context)
         df = df[df_condition]
 
         df = self.fix_column_to_row_type(df, rel.getRowType())

--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -36,12 +36,12 @@ class LogicalJoinPlugin(BaseRelPlugin):
     }
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
+        self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
     ) -> dd.DataFrame:
         # Joining is a bit more complicated, so lets do it in steps:
 
         # 1. We now have two inputs (from left and right), so we fetch them both
-        df_lhs, df_rhs = self.assert_inputs(rel, 2, tables)
+        df_lhs, df_rhs = self.assert_inputs(rel, 2, context)
 
         # 2. dask's merge will do some smart things with columns, which have the same name
         # on lhs an rhs (which also includes reordering).
@@ -116,7 +116,10 @@ class LogicalJoinPlugin(BaseRelPlugin):
             # This line is a bit of code duplication with RexCallPlugin - but I guess it is worth to keep it separate
             filter_condition = reduce(
                 operator.and_,
-                [RexConverter.convert(rex, df) for rex in filter_condition],
+                [
+                    RexConverter.convert(rex, df, context=context)
+                    for rex in filter_condition
+                ],
             )
             df = df[filter_condition]
 

--- a/dask_sql/physical/rel/logical/project.py
+++ b/dask_sql/physical/rel/logical/project.py
@@ -16,17 +16,17 @@ class LogicalProjectPlugin(BaseRelPlugin):
     class_name = "org.apache.calcite.rel.logical.LogicalProject"
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
+        self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
     ) -> dd.DataFrame:
         # Get the input of the previous step
-        (df,) = self.assert_inputs(rel, 1, tables)
+        (df,) = self.assert_inputs(rel, 1, context)
 
         # It is easiest to just replace all columns with the new ones
         named_projects = rel.getNamedProjects()
 
         new_columns = {}
         for expr, key in named_projects:
-            new_columns[str(key)] = RexConverter.convert(expr, df)
+            new_columns[str(key)] = RexConverter.convert(expr, df, context=context)
 
         df = df.drop(columns=list(df.columns)).assign(**new_columns)
 

--- a/dask_sql/physical/rel/logical/sort.py
+++ b/dask_sql/physical/rel/logical/sort.py
@@ -19,9 +19,9 @@ class LogicalSortPlugin(BaseRelPlugin):
     class_name = "org.apache.calcite.rel.logical.LogicalSort"
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
+        self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
     ) -> dd.DataFrame:
-        (df,) = self.assert_inputs(rel, 1, tables)
+        (df,) = self.assert_inputs(rel, 1, context)
         self.check_columns_from_row_type(df, rel.getExpectedInputRowType(0))
 
         sort_collation = rel.getCollation().getFieldCollations()
@@ -30,11 +30,11 @@ class LogicalSortPlugin(BaseRelPlugin):
 
         offset = rel.offset
         if offset:
-            offset = RexConverter.convert(offset, df)
+            offset = RexConverter.convert(offset, df, context=context)
 
         end = rel.fetch
         if end:
-            end = RexConverter.convert(end, df)
+            end = RexConverter.convert(end, df, context=context)
 
             if offset:
                 end += offset

--- a/dask_sql/physical/rel/logical/table_scan.py
+++ b/dask_sql/physical/rel/logical/table_scan.py
@@ -20,7 +20,7 @@ class LogicalTableScanPlugin(BaseRelPlugin):
     class_name = "org.apache.calcite.rel.logical.LogicalTableScan"
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
+        self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
     ) -> dd.DataFrame:
         # There should not be any input. This is the first step.
         self.assert_inputs(rel, 0)
@@ -36,8 +36,9 @@ class LogicalTableScanPlugin(BaseRelPlugin):
         assert table_names[0] == "schema"
         assert len(table_names) == 2
         table_name = table_names[1]
+        table_name = table_name.lower()
 
-        df = tables[table_name]
+        df = context.tables[table_name]
 
         # Make sure we only return the requested columns
         row_type = table.getRowType()

--- a/dask_sql/physical/rel/logical/union.py
+++ b/dask_sql/physical/rel/logical/union.py
@@ -15,9 +15,9 @@ class LogicalUnionPlugin(BaseRelPlugin):
     class_name = "org.apache.calcite.rel.logical.LogicalUnion"
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
+        self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
     ) -> dd.DataFrame:
-        first_df, second_df = self.assert_inputs(rel, 2, tables)
+        first_df, second_df = self.assert_inputs(rel, 2, context)
 
         # For concatenating, they should have exactly the same fields
         output_field_names = [str(x) for x in rel.getRowType().getFieldNames()]

--- a/dask_sql/physical/rel/logical/values.py
+++ b/dask_sql/physical/rel/logical/values.py
@@ -24,7 +24,7 @@ class LogicalValuesPlugin(BaseRelPlugin):
     class_name = "org.apache.calcite.rel.logical.LogicalValues"
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", tables: Dict[str, dd.DataFrame]
+        self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
     ) -> dd.DataFrame:
         # There should not be any input. This is the first step.
         self.assert_inputs(rel, 0)
@@ -32,7 +32,12 @@ class LogicalValuesPlugin(BaseRelPlugin):
         rex_expression_rows = list(rel.getTuples())
         rows = []
         for rex_expressions in rex_expression_rows:
-            rows.append([RexConverter.convert(rex, None) for rex in rex_expressions])
+            rows.append(
+                [
+                    RexConverter.convert(rex, None, context=context)
+                    for rex in rex_expressions
+                ]
+            )
 
         # We assume here that when using the values plan, the resulting dataframe will be quite small
         # TODO: we explicitely reference pandas and dask here -> might we worth making this more general

--- a/dask_sql/physical/rex/base.py
+++ b/dask_sql/physical/rex/base.py
@@ -15,7 +15,10 @@ class BaseRexPlugin:
     class_name = None
 
     def convert(
-        self, rex: "org.apache.calcite.rex.RexNode", df: dd.DataFrame
+        self,
+        rex: "org.apache.calcite.rex.RexNode",
+        df: dd.DataFrame,
+        context: "dask_sql.Context",
     ) -> Union[dd.Series, Any]:
         """Base method to implement"""
         raise NotImplementedError  # pragma: no cover

--- a/dask_sql/physical/rex/convert.py
+++ b/dask_sql/physical/rex/convert.py
@@ -30,7 +30,10 @@ class RexConverter(Pluggable):
 
     @classmethod
     def convert(
-        cls, rex: "org.apache.calcite.rex.RexNode", df: dd.DataFrame
+        cls,
+        rex: "org.apache.calcite.rex.RexNode",
+        df: dd.DataFrame,
+        context: "dask_sql.Context",
     ) -> Union[dd.DataFrame, Any]:
         """
         Convert the given rel (java instance)
@@ -47,5 +50,5 @@ class RexConverter(Pluggable):
                 f"No conversion for class {class_name} available (yet)."
             )
 
-        df = plugin_instance.convert(rex, df=df)
+        df = plugin_instance.convert(rex, df=df, context=context)
         return df

--- a/dask_sql/physical/rex/core/input_ref.py
+++ b/dask_sql/physical/rex/core/input_ref.py
@@ -13,7 +13,10 @@ class RexInputRefPlugin(BaseRexPlugin):
     class_name = "org.apache.calcite.rex.RexInputRef"
 
     def convert(
-        self, rex: "org.apache.calcite.rex.RexNode", df: dd.DataFrame
+        self,
+        rex: "org.apache.calcite.rex.RexNode",
+        df: dd.DataFrame,
+        context: "dask_sql.Context",
     ) -> dd.Series:
         # The column is references by index
         index = rex.getIndex()

--- a/dask_sql/physical/rex/core/literal.py
+++ b/dask_sql/physical/rex/core/literal.py
@@ -18,7 +18,12 @@ class RexLiteralPlugin(BaseRexPlugin):
 
     class_name = "org.apache.calcite.rex.RexLiteral"
 
-    def convert(self, rex: "org.apache.calcite.rex.RexNode", df: dd.DataFrame) -> Any:
+    def convert(
+        self,
+        rex: "org.apache.calcite.rex.RexNode",
+        df: dd.DataFrame,
+        context: "dask_sql.Context",
+    ) -> Any:
         literal_value = rex.getValue()
 
         literal_type = str(rex.getType())

--- a/planner/src/main/java/com/dask/sql/schema/DaskAggregateFunction.java
+++ b/planner/src/main/java/com/dask/sql/schema/DaskAggregateFunction.java
@@ -1,0 +1,13 @@
+package com.dask.sql.schema;
+
+import org.apache.calcite.schema.AggregateFunction;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/**
+ * Aggregate function class. See DaskFunction for more description.
+ */
+public class DaskAggregateFunction extends DaskFunction implements AggregateFunction {
+	public DaskAggregateFunction(String name, SqlTypeName returnType) {
+		super(name, returnType);
+	}
+}

--- a/planner/src/main/java/com/dask/sql/schema/DaskFunction.java
+++ b/planner/src/main/java/com/dask/sql/schema/DaskFunction.java
@@ -1,0 +1,54 @@
+package com.dask.sql.schema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.FunctionParameter;
+import org.apache.calcite.schema.ScalarFunction;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/**
+ * A function (placeholder) in the form, that calcite understands.
+ *
+ * Basically just a name, a return type and the list of parameters. Please note
+ * that this function has no implementation but just serves as a name, which
+ * calcite will return to dask_sql again.
+ */
+public class DaskFunction {
+	/// The internal storage of parameters
+	private final List<FunctionParameter> parameters;
+	/// The internal storage of the return type
+	private final SqlTypeName returnType;
+	/// The internal storage of the name
+	private final String name;
+
+	/// Create a new function out of the given parameters and return type
+	public DaskFunction(final String name, final SqlTypeName returnType) {
+		this.name = name;
+		this.parameters = new ArrayList<FunctionParameter>();
+		this.returnType = returnType;
+	}
+
+	/// Add a new parameter
+	public void addParameter(String name, SqlTypeName parameterSqlType, boolean optional) {
+		this.parameters.add(new DaskFunctionParameter(this.parameters.size(), name, parameterSqlType, optional));
+	}
+
+	/// Return the name of the function
+	public String getFunctionName() {
+		return this.name;
+	}
+
+	/// The list of parameters of the function
+	public List<FunctionParameter> getParameters() {
+		return this.parameters;
+	}
+
+	/// The return type of the function
+	public RelDataType getReturnType(final RelDataTypeFactory relDataTypeFactory) {
+		return relDataTypeFactory.createSqlType(this.returnType);
+	}
+
+}

--- a/planner/src/main/java/com/dask/sql/schema/DaskFunctionParameter.java
+++ b/planner/src/main/java/com/dask/sql/schema/DaskFunctionParameter.java
@@ -1,0 +1,59 @@
+package com.dask.sql.schema;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.FunctionParameter;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/**
+ * Helper class to store a function parameter in a form that calcite
+ * understands.
+ */
+public class DaskFunctionParameter implements FunctionParameter {
+	/// Internal storage of the parameter position
+	private final int ordinal;
+	/// Internal storage of the parameter name
+	private final String name;
+	/// Internal storage of the parameter type
+	private final SqlTypeName parameterSqlType;
+	/// Internal storage if the parameter is optional
+	private final boolean optional;
+
+	/// Create a new function parameter from the parameters
+	public DaskFunctionParameter(int ordinal, String name, SqlTypeName parameterSqlType, boolean optional) {
+		this.ordinal = ordinal;
+		this.name = name;
+		this.parameterSqlType = parameterSqlType;
+		this.optional = optional;
+	}
+
+	/// Create a new function parameter from the parameters
+	public DaskFunctionParameter(int ordinal, String name, SqlTypeName parameterSqlType) {
+		this(ordinal, name, parameterSqlType, false);
+	}
+
+	/// The position of this parameter
+	@Override
+	public int getOrdinal() {
+		return this.ordinal;
+	}
+
+	/// The name of this parameter
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
+	/// Type of the parameter
+	@Override
+	public RelDataType getType(RelDataTypeFactory relDataTypeFactory) {
+		return relDataTypeFactory.createSqlType(this.parameterSqlType);
+	}
+
+	/// Is the parameter optional=
+	@Override
+	public boolean isOptional() {
+		return this.optional;
+	}
+
+}

--- a/planner/src/main/java/com/dask/sql/schema/DaskScalarFunction.java
+++ b/planner/src/main/java/com/dask/sql/schema/DaskScalarFunction.java
@@ -1,0 +1,13 @@
+package com.dask.sql.schema;
+
+import org.apache.calcite.schema.ScalarFunction;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/**
+ * Scalar function class. See DaskFunction for more description.
+ */
+public class DaskScalarFunction extends DaskFunction implements ScalarFunction {
+	public DaskScalarFunction(String name, SqlTypeName returnType) {
+		super(name, returnType);
+	}
+}

--- a/tests/integration/test_function.py
+++ b/tests/integration/test_function.py
@@ -28,7 +28,7 @@ class FunctionTestCase(DaskTestCase):
 
         df = self.c.sql(
             """
-            SELECT fagg(b) AS test, sum(b) AS S
+            SELECT fagg(b) AS test, sum(b) AS "S"
             FROM df
             """
         )

--- a/tests/integration/test_function.py
+++ b/tests/integration/test_function.py
@@ -1,0 +1,37 @@
+import numpy as np
+from pandas.testing import assert_frame_equal
+import dask.dataframe as dd
+
+from tests.integration.fixtures import DaskTestCase
+
+
+class FunctionTestCase(DaskTestCase):
+    def test_custom_function(self):
+        def f(x):
+            return x ** 2
+
+        self.c.register_function(f, "f", [("x", np.int64)], np.int64)
+
+        df = self.c.sql(
+            """
+            SELECT f(a) AS a
+            FROM df
+            """
+        )
+        df = df.compute()
+
+        assert_frame_equal(df.reset_index(drop=True), self.df[["a"]] ** 2)
+
+    def test_aggregate_function(self):
+        fagg = dd.Aggregation("f", lambda x: x.sum(), lambda x: x.sum())
+        self.c.register_aggregation(fagg, "fagg", [("x", np.float64)], np.float64)
+
+        df = self.c.sql(
+            """
+            SELECT fagg(b) AS test, sum(b) AS S
+            FROM df
+            """
+        )
+        df = df.compute()
+
+        assert (df["test"] == df["S"]).all()


### PR DESCRIPTION
This PR adds the possibility to add custom user-defined functions to the context, which are called during processing.

There exist two different types of functions.

* scalar functions (such as x -> x**2) can be run on a column (or multiple) and turn them again into a column (of the same length)

Example:

```python
def f(x):
    return x ** 2

c.register_function(f, "f", [("x", np.int64)], np.int64)

sql = "SELECT f(x) FROM df"
df_result = c.sql(sql)
```

* aggregation functions (`dask.dataframe.Aggregation`) can be run on a single column (or multiple) and turn them into a single value (which means they can only be used in aggregations).

Example:

```python
fagg = dd.Aggregation("fagg", lambda x: x.sum(), lambda x: x.sum())
c.register_aggregation(fagg, "fagg", [("x", np.float64)], np.float64)

sql = "SELECT fagg(y) FROM df GROUP BY x"
df_result = c.sql(sql)
```

There can only ever exist a single function with the same name.