### PR TITLE
Add more aggregation types and filtered aggregations

### DIFF
--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -134,7 +134,9 @@ class LogicalAggregatePlugin(BaseRelPlugin):
             if df_agg is None:
                 df_agg = filtered_df_agg
             else:
-                df_agg = dd.concat([df_agg, filtered_df_agg], axis=1)
+                df_agg = df_agg.assign(
+                    **{col: filtered_df_agg[col] for col in filtered_df_agg.columns}
+                )
 
         # SQL does not care about the index, but we do not want to have any multiindices
         df_agg = df_agg.reset_index(drop=True)

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -1,14 +1,48 @@
 import operator
 from collections import defaultdict
-from typing import Dict, List, Tuple, Callable
 from functools import reduce
+from typing import Callable, Dict, List, Tuple, Union
 
 import dask.dataframe as dd
 
 from dask_sql.physical.rel.base import BaseRelPlugin
 
 
+class GroupDatasetDescription:
+    """
+    Helper class to put dataframes which are filtered according to a specific column
+    into a dictionary.
+    Applying the same filter twice on the same dataframe does not give different
+    dataframes. Therefore we only hash these dataframes according to the column
+    they are filtered by.
+    """
+
+    def __init__(self, df: dd.DataFrame, filtered_column: str = ""):
+        self.df = df
+        self.filtered_column = filtered_column
+
+    def __eq__(self, rhs: "GroupDatasetDescription") -> bool:
+        """They are equal of they are filtered by the same column"""
+        return self.filtered_column == rhs.filtered_column
+
+    def __hash__(self) -> str:
+        return hash(self.filtered_column)
+
+    def __repr__(self) -> str:
+        return f"GroupDatasetDescription({self.filtered_column})"
+
+
+# Description of an aggregation in the form of a mapping
+# input column -> output column -> aggregation
+AggregationDescription = Dict[str, Dict[str, Union[str, dd.Aggregation]]]
+
+
 class ReduceAggregation(dd.Aggregation):
+    """
+    A special form of an aggregation, that applies a given operation
+    on all elements in a group with "reduce".
+    """
+
     def __init__(self, name: str, operation: Callable):
         series_aggregate = lambda s: s.aggregate(lambda x: reduce(operation, x))
 
@@ -71,7 +105,7 @@ class LogicalAggregatePlugin(BaseRelPlugin):
         df = df.assign(**{additional_column_name: 1})
 
         # Collect all aggregates
-        aggregations, output_column_order = self._collect_aggregations(
+        filtered_aggregations, output_column_order = self._collect_aggregations(
             rel, df, group_columns, additional_column_name, context
         )
 
@@ -85,18 +119,33 @@ class LogicalAggregatePlugin(BaseRelPlugin):
             group_columns = [additional_column_name]
 
         # Now we can perform the aggregates
-        df = df.groupby(by=group_columns).agg(aggregations)
+        # We iterate through all pairs of (possible pre-filtered)
+        # dataframes and the aggregations to perform in this data...
+        df_agg = None
+        for filtered_df_desc, aggregation in filtered_aggregations.items():
+            # ... we perform the aggregations ...
+            filtered_df = filtered_df_desc.df
+            filtered_df_agg = filtered_df.groupby(by=group_columns).agg(aggregation)
+
+            # ... fix the column names to a single level ...
+            filtered_df_agg.columns = filtered_df_agg.columns.get_level_values(-1)
+
+            # ... and finally concat the new data with the already present columns
+            if df_agg is None:
+                df_agg = filtered_df_agg
+            else:
+                df_agg = dd.concat([df_agg, filtered_df_agg], axis=1)
 
         # SQL does not care about the index, but we do not want to have any multiindices
-        df = df.reset_index(drop=True)
+        df_agg = df_agg.reset_index(drop=True)
 
         # Fix the column names and the order of them, as this was messed with during the aggregations
-        df.columns = df.columns.get_level_values(-1)
-        df = df[output_column_order]
+        df_agg.columns = df_agg.columns.get_level_values(-1)
+        df_agg = df_agg[output_column_order]
 
-        df = self.fix_column_to_row_type(df, rel.getRowType())
+        df_agg = self.fix_column_to_row_type(df_agg, rel.getRowType())
 
-        return df
+        return df_agg
 
     def _collect_aggregations(
         self,
@@ -105,19 +154,35 @@ class LogicalAggregatePlugin(BaseRelPlugin):
         group_columns: List[str],
         additional_column_name: str,
         context: "dask_sql.Context",
-    ) -> Tuple[Dict[str, Dict[str, str]], List[int]]:
-        aggregations = defaultdict(dict)
+    ) -> Tuple[
+        Dict[GroupDatasetDescription, AggregationDescription], List[int],
+    ]:
+        """
+        Create a mapping of dataframe -> aggregations (in the form input colum, output column, aggregation)
+        and the expected order of output columns.
+        """
+        aggregations = defaultdict(lambda: defaultdict(dict))
         output_column_order = []
 
-        # SQL needs to copy the old content also. As the values are the same for a single group
-        # anyways, we just use the first row
+        # SQL needs to copy the old content also. As the values of the group columns
+        # are the same for a single group anyways, we just use the first row
         for col in group_columns:
-            aggregations[col][col] = "first"
+            aggregations[GroupDatasetDescription(df)][col][col] = "first"
             output_column_order.append(col)
 
+        # Now collect all aggregations
         for agg_call in rel.getNamedAggCalls():
-            output_column_name = str(agg_call.getValue())
+            output_col = str(agg_call.getValue())
             expr = agg_call.getKey()
+
+            if expr.hasFilter():
+                filter_column = expr.filterArg
+                filter_expression = df.iloc[:, filter_column]
+                filtered_df = df[filter_expression]
+
+                grouped_df = GroupDatasetDescription(filtered_df, filter_column)
+            else:
+                grouped_df = GroupDatasetDescription(df)
 
             if expr.isDistinct():
                 raise NotImplementedError(
@@ -138,15 +203,15 @@ class LogicalAggregatePlugin(BaseRelPlugin):
 
             inputs = expr.getArgList()
             if len(inputs) == 1:
-                input_column_name = df.columns[inputs[0]]
+                input_col = df.columns[inputs[0]]
             elif len(inputs) == 0:
-                input_column_name = additional_column_name
+                input_col = additional_column_name
             else:
                 raise NotImplementedError(
                     "Can not cope with more than one input"
                 )  # pragma: no cover
 
-            aggregations[input_column_name][output_column_name] = aggregation_function
-            output_column_order.append(output_column_name)
+            aggregations[grouped_df][input_col][output_col] = aggregation_function
+            output_column_order.append(output_col)
 
         return aggregations, output_column_order

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -64,6 +64,22 @@ class CaseOperation(Operation):
             return then if where else other  # pragma: no cover
 
 
+class IsTrueOperation(Operation):
+    """The is true operator"""
+
+    def __init__(self):
+        super().__init__(self.true_)
+
+    def true_(self, df: Union[dd.Series, Any],) -> Union[dd.Series, Any]:
+        """
+        Returns true where `df` is true (where `df` can also be just a scalar).
+        """
+        if is_frame(df):
+            return df.astype(bool)
+
+        return bool(df)
+
+
 class LikeOperation(Operation):
     """The like operator (regex for SQL with some twist)"""
 
@@ -180,6 +196,7 @@ class RexCallPlugin(BaseRexPlugin):
         "*": ReduceOperation(operation=operator.mul),
         "case": CaseOperation(),
         "like": LikeOperation(),
+        "is true": IsTrueOperation(),
     }
 
     def convert(

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -61,7 +61,7 @@ class CaseOperation(Operation):
             tmp = where.apply(lambda x: then, meta=(where.name, type(then)))
             return tmp.where(where, other=other)
         else:
-            return then if where else other  # pragma: no cover
+            return then if where else other
 
 
 class IsTrueOperation(Operation):

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -36,6 +36,20 @@ class GroupbyTestCase(DaskTestCase):
         expected_df["X"] = expected_df["X"].astype("int32")
         assert_frame_equal(df, expected_df)
 
+    def test_group_by_filtered(self):
+        df = self.c.sql(
+            """
+        SELECT
+            SUM(b) FILTER (WHERE user_id = 2) AS "S"
+        FROM user_table_1
+        """
+        )
+        df = df.compute()
+
+        expected_df = pd.DataFrame({"S": [4]})
+        expected_df["S"] = expected_df["S"].astype("int64")
+        assert_frame_equal(df, expected_df)
+
     def test_group_by_case(self):
         df = self.c.sql(
             """

--- a/tests/unit/test_call.py
+++ b/tests/unit/test_call.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock
+import operator
+
+import dask.dataframe as dd
+import pandas as pd
+from pandas.testing import assert_series_equal
+
+import dask_sql.physical.rex.core.call as call
+
+df1 = dd.from_pandas(pd.DataFrame({"a": [1, 2, 3]}), npartitions=1)
+df2 = dd.from_pandas(pd.DataFrame({"a": [3, 2, 1]}), npartitions=1)
+
+
+def test_operation():
+    operator = MagicMock()
+    operator.return_value = "test"
+
+    op = call.Operation(operator)
+
+    assert op("input") == "test"
+    operator.assert_called_once_with("input")
+
+
+def test_reduce():
+    op = call.ReduceOperation(operator.add)
+
+    assert op(1, 2, 3) == 6
+
+
+def test_case():
+    op = call.CaseOperation()
+
+    assert_series_equal(
+        op(df1.a > 2, df1.a, df2.a).compute(), pd.Series([3, 2, 3]), check_names=False
+    )
+
+    assert_series_equal(
+        op(df1.a > 2, 99, df2.a).compute(), pd.Series([3, 2, 99]), check_names=False
+    )
+
+    assert_series_equal(
+        op(df1.a > 2, 99, -1).compute(), pd.Series([-1, -1, 99]), check_names=False
+    )
+
+    assert_series_equal(
+        op(df1.a > 2, df1.a, -1).compute(), pd.Series([-1, -1, 3]), check_names=False
+    )
+
+    assert op(True, 1, 2) == 1
+    assert op(False, 1, 2) == 2
+
+
+def test_is_truease():
+    op = call.IsTrueOperation()
+
+    assert_series_equal(
+        op(df1.a > 2).compute(), pd.Series([False, False, True]), check_names=False
+    )
+    assert_series_equal(
+        op(df2.a).compute(), pd.Series([True, True, True]), check_names=False
+    )
+
+    assert op(1) == True
+    assert op(0) == False
+
+
+def test_like():
+    op = call.LikeOperation()
+
+    assert op("a string", r"%a%") == True
+    assert op("another string", r"a%") == True
+    assert op("another string", r"s%") == False
+    assert op("normal", r"n[a-z]rm_l") == True
+    assert op("not normal", r"n[a-z]rm_l") == False
+
+
+def test_simple_ops():
+    ops_mapping = call.RexCallPlugin.OPERATION_MAPPING
+
+    assert_series_equal(
+        ops_mapping["and"](df1.a >= 2, df2.a >= 2).compute(),
+        pd.Series([False, True, False]),
+        check_names=False,
+    )
+
+    assert_series_equal(
+        ops_mapping["or"](df1.a >= 2, df2.a >= 2).compute(),
+        pd.Series([True, True, True]),
+        check_names=False,
+    )
+
+    assert_series_equal(
+        ops_mapping[">="](df1.a, df2.a).compute(),
+        pd.Series([False, True, True]),
+        check_names=False,
+    )
+
+    assert_series_equal(
+        ops_mapping["+"](df1.a, df2.a, df1.a).compute(),
+        pd.Series([5, 6, 7]),
+        check_names=False,
+    )


### PR DESCRIPTION
This PR adds additional aggregations, the possibility to use filtered aggregations such as
```sql
SELECT SUM(x) FILTER (WHERE x > 3) FROM df GROUP BY y
```
and one additional operation is true (which is typically needed for those filters).

It therefore touches #11 and #9 