### PR TITLE
Do only map known columns

### DIFF
--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -156,6 +156,7 @@ class DataContainer:
             **{
                 col_from: self.df[col_to]
                 for col_from, col_to in self.column_container.mapping()
+                if col_from in self.column_container.columns
             }
         )
         return df[self.column_container.columns]

--- a/tests/integration/test_complex.py
+++ b/tests/integration/test_complex.py
@@ -40,4 +40,3 @@ class TimeSeriesTestCase(TestCase):
         df = result.compute()
 
         self.assertGreater(len(df), 0)
-

--- a/tests/integration/test_complex.py
+++ b/tests/integration/test_complex.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+
+from dask.datasets import timeseries
+
+from dask_sql import Context
+
+
+class TimeSeriesTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.c = Context()
+
+        df = timeseries().persist()
+        cls.c.register_dask_table(df, "timeseries")
+
+    def test_complex_query(self):
+        result = self.c.sql(
+            """
+            SELECT
+                lhs.name,
+                lhs.id,
+                lhs.x
+            FROM
+                timeseries AS lhs
+            JOIN
+                (
+                    SELECT
+                        name AS max_name,
+                        MAX(x) AS max_x
+                    FROM timeseries
+                    GROUP BY name
+                ) AS rhs
+            ON
+                lhs.name = rhs.max_name AND
+                lhs.x = rhs.max_x
+        """
+        )
+
+        # should not fail
+        df = result.compute()
+
+        self.assertGreater(len(df), 0)
+


### PR DESCRIPTION
After the refactoring for faster speed (#29), the columns on the frontend and backend might be different.
However, that might lead to problems in the `assign` function, which assumes all of those columns are there. This PR fixes this problem and adds a more complex test against regression.