### PR TITLE
Implement correct SQL division

### DIFF
--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -109,6 +109,18 @@ class RexOperationsTestCase(DaskTestCase):
         expected_df["n"] = self.df["a"] != self.df["b"]
         assert_frame_equal(df, expected_df)
 
+    def test_integer_division(self):
+        df = self.c.sql(
+            """
+            SELECT
+                1 / b AS b
+            FROM
+                user_table_1
+            """
+        ).compute()
+
+        assert_frame_equal(df, pd.DataFrame({"b": [0.0, 0.0, 1.0, 0.0]}))
+
     def test_like(self):
         df = self.c.sql(
             """


### PR DESCRIPTION
SQL division is different from normal python operation, as it truncates instead of floors.
This means -1 / 2 = 0 instead of -1.