### PR TITLE
Added some debug logging

### DIFF
--- a/dask_sql/java.py
+++ b/dask_sql/java.py
@@ -6,8 +6,11 @@ It needs to know the java class path, which is set
 to the jar file in the package resources.
 """
 import pkg_resources
+import logging
 
 import jpype
+
+logger = logging.getLogger(__name__)
 
 
 # Define how to run the java virtual machine.
@@ -19,6 +22,7 @@ jpype.addClassPath(pkg_resources.resource_filename("dask_sql", "jar/DaskSQL.jar"
 jvmpath = jpype.getDefaultJVMPath()
 jvmpath = jvmpath.replace("\\bin\\bin\\server\\jvm.dll", "\\bin\\server\\jvm.dll")
 
+logger.debug(f"Starting JVM from path {jvmpath}...")
 jpype.startJVM(
     "-ea",
     "--illegal-access=deny",
@@ -26,6 +30,7 @@ jpype.startJVM(
     convertStrings=False,
     jvmpath=jvmpath,
 )
+logger.debug("...having started JVM")
 
 
 # Some Java classes we need

--- a/dask_sql/physical/rel/base.py
+++ b/dask_sql/physical/rel/base.py
@@ -1,4 +1,5 @@
-from typing import Dict, List
+from typing import List
+import logging
 
 import dask.dataframe as dd
 import dask.array as da
@@ -6,6 +7,8 @@ import pandas as pd
 
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.mappings import sql_to_python_type, similar_type
+
+logger = logging.getLogger(__name__)
 
 
 class BaseRelPlugin:
@@ -114,6 +117,9 @@ class BaseRelPlugin:
             if current_float and expected_integer:
                 df[field_name] = da.trunc(df[field_name])
 
+            logger.debug(
+                f"Need to cast {field_name} from {current_type} to {expected_type}"
+            )
             df[field_name] = df[field_name].astype(expected_type)
 
         return DataContainer(df, dc.column_container)

--- a/dask_sql/physical/rel/convert.py
+++ b/dask_sql/physical/rel/convert.py
@@ -1,10 +1,12 @@
-from typing import Dict
+import logging
 
 import dask.dataframe as dd
 
 from dask_sql.java import get_java_class
-from dask_sql.utils import Pluggable
+from dask_sql.utils import LoggableDataFrame, Pluggable
 from dask_sql.physical.rel.base import BaseRelPlugin
+
+logger = logging.getLogger(__name__)
 
 
 class RelConverter(Pluggable):
@@ -26,6 +28,7 @@ class RelConverter(Pluggable):
     @classmethod
     def add_plugin_class(cls, plugin_class: BaseRelPlugin, replace=True):
         """Convenience function to add a class directly to the plugins"""
+        logger.debug(f"Registering REL plugin for {plugin_class.class_name}")
         cls.add_plugin(plugin_class.class_name, plugin_class(), replace=replace)
 
     @classmethod
@@ -47,5 +50,9 @@ class RelConverter(Pluggable):
                 f"No conversion for class {class_name} available (yet)."
             )
 
+        logger.debug(
+            f"Processing REL {rel} using {plugin_instance.__class__.__name__}..."
+        )
         df = plugin_instance.convert(rel, context=context)
+        logger.debug(f"Processed REL {rel} into {LoggableDataFrame(df)}")
         return df

--- a/dask_sql/physical/rel/logical/project.py
+++ b/dask_sql/physical/rel/logical/project.py
@@ -1,12 +1,12 @@
-from typing import Dict
-
-import dask.dataframe as dd
+import logging
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rex.core.input_ref import RexInputRefPlugin
 from dask_sql.physical.rel.base import BaseRelPlugin
 from dask_sql.datacontainer import DataContainer
 from dask_sql.java import get_java_class
+
+logger = logging.getLogger(__name__)
 
 
 class LogicalProjectPlugin(BaseRelPlugin):
@@ -41,9 +41,13 @@ class LogicalProjectPlugin(BaseRelPlugin):
             if get_java_class(expr) == RexInputRefPlugin.class_name:
                 index = expr.getIndex()
                 backend_column_name = cc.get_backend_by_frontend_index(index)
+                logger.debug(
+                    f"Not re-adding the same column {key} (but just referencing it)"
+                )
                 cc = cc.add(key, backend_column_name)
             else:
                 new_columns[key] = RexConverter.convert(expr, dc, context=context)
+                logger.debug(f"Adding a new column {key} out of {expr}")
                 cc = cc.add(key, key)
 
         # Actually add the new columns

--- a/dask_sql/physical/rel/logical/union.py
+++ b/dask_sql/physical/rel/logical/union.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import dask.dataframe as dd
 
 from dask_sql.physical.rex import RexConverter

--- a/dask_sql/physical/rel/logical/values.py
+++ b/dask_sql/physical/rel/logical/values.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import dask.dataframe as dd
 import pandas as pd
 

--- a/dask_sql/physical/rex/convert.py
+++ b/dask_sql/physical/rex/convert.py
@@ -1,11 +1,14 @@
 from typing import Union, Any
+import logging
 
 import dask.dataframe as dd
 
 from dask_sql.java import get_java_class
-from dask_sql.utils import Pluggable
+from dask_sql.utils import LoggableDataFrame, Pluggable
 from dask_sql.physical.rex.base import BaseRexPlugin
 from dask_sql.datacontainer import DataContainer
+
+logger = logging.getLogger(__name__)
 
 
 class RexConverter(Pluggable):
@@ -27,6 +30,7 @@ class RexConverter(Pluggable):
     @classmethod
     def add_plugin_class(cls, plugin_class: BaseRexPlugin, replace=True):
         """Convenience function to add a class directly to the plugins"""
+        logger.debug(f"Registering REX plugin for {plugin_class.class_name}")
         cls.add_plugin(plugin_class.class_name, plugin_class(), replace=replace)
 
     @classmethod
@@ -51,5 +55,10 @@ class RexConverter(Pluggable):
                 f"No conversion for class {class_name} available (yet)."
             )
 
+        logger.debug(
+            f"Processing REX {rex} using {plugin_instance.__class__.__name__}..."
+        )
+
         df = plugin_instance.convert(rex, dc, context=context)
+        logger.debug(f"Processed REX {rex} into {LoggableDataFrame(df)}")
         return df

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -1,8 +1,8 @@
 import operator
-from collections import namedtuple
 from functools import reduce
 from typing import Any, Union, Callable
 import re
+import logging
 
 import pandas as pd
 import numpy as np
@@ -12,8 +12,10 @@ import pandas as pd
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rex.base import BaseRexPlugin
-from dask_sql.utils import is_frame
+from dask_sql.utils import LoggableDataFrame, is_frame
 from dask_sql.datacontainer import DataContainer
+
+logger = logging.getLogger(__name__)
 
 
 class Operation:
@@ -454,6 +456,9 @@ class RexCallPlugin(BaseRexPlugin):
             except KeyError:
                 raise NotImplementedError(f"{operator_name} not (yet) implemented")
 
+        logger.debug(
+            f"Executing {operator_name} on {[str(LoggableDataFrame(df)) for df in operands]}"
+        )
         return operation(*operands)
 
         # TODO: We have information on the typing here - we should use it

--- a/dask_sql/utils.py
+++ b/dask_sql/utils.py
@@ -146,4 +146,3 @@ class LoggableDataFrame:
             return f"DataFrame: {[(col, dtype) for col, dtype in zip(cols, dtypes)]}"
 
         return f"Literal: {df}"
-

--- a/dask_sql/utils.py
+++ b/dask_sql/utils.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
+from dask_sql.datacontainer import DataContainer
 import re
 
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 
@@ -123,3 +125,25 @@ class ParsingException(Exception):
         message += "\n\t" + "\n\t".join(sql)
 
         return message
+
+
+class LoggableDataFrame:
+    """Small helper class to print resulting dataframes or series in logging messages"""
+
+    def __init__(self, df):
+        self.df = df
+
+    def __str__(self):
+        df = self.df
+        if isinstance(df, pd.Series) or isinstance(df, dd.Series):
+            return f"Series: {(df.name, df.dtype)}"
+
+        elif isinstance(df, DataContainer):
+            cols = df.column_container.columns
+            dtypes = {col: dtype for col, dtype in zip(df.df.columns, df.df.dtypes)}
+            mapping = df.column_container.get_backend_by_frontend_index
+            dtypes = [dtypes[mapping(index)] for index in range(len(cols))]
+            return f"DataFrame: {[(col, dtype) for col, dtype in zip(cols, dtypes)]}"
+
+        return f"Literal: {df}"
+

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -102,7 +102,7 @@ class ComparisonTestCase(TestCase):
 
     def assert_query_gives_same_result(self, query, sort_columns=None, **kwargs):
         sql_result = pd.read_sql_query(query, self.engine)
-        dask_result = self.c.sql(query, debug=True).compute()
+        dask_result = self.c.sql(query).compute()
 
         # allow that the names are different
         # as expressions are handled differently

--- a/tests/integration/test_join.py
+++ b/tests/integration/test_join.py
@@ -117,8 +117,7 @@ class JoinTestCase(DaskTestCase):
                     df_simple AS lhs
                 JOIN df_simple AS rhs
                 ON lhs.a < rhs.b AND lhs.b < rhs.a
-            """,
-            debug=True,
+            """
         )
         df = df.compute()
 
@@ -188,8 +187,7 @@ class JoinTestCase(DaskTestCase):
         FROM user_table_1 AS lhs
         JOIN user_table_2 AS rhs
             ON False
-        """,
-            debug=True,
+        """
         )
 
         df = df.compute()

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -94,8 +94,7 @@ class RexOperationsTestCase(DaskTestCase):
             a <= b AS le,
             a <> b AS n
         FROM df
-        """,
-            debug=True,
+        """
         )
         df = df.compute()
 
@@ -237,8 +236,7 @@ class RexOperationsTestCase(DaskTestCase):
                 , TAN(b) AS "tan"
                 , TRUNCATE(b) AS "truncate"
             FROM df
-        """,
-            debug=True,
+        """
         ).compute()
 
         expected_df = pd.DataFrame(index=self.df.index)
@@ -275,8 +273,7 @@ class RexOperationsTestCase(DaskTestCase):
                 a / 2 AS b,
                 1.0 / a AS c
             FROM df_simple
-        """,
-            debug=True,
+        """
         ).compute()
 
         expected_df = pd.DataFrame(index=self.df_simple.index)
@@ -300,8 +297,7 @@ class RexOperationsTestCase(DaskTestCase):
                     WHERE
                         user_table_1.b = user_table_2.c
                 )
-        """,
-            debug=True,
+        """
         ).compute()
 
         assert_frame_equal(

--- a/tests/integration/test_select.py
+++ b/tests/integration/test_select.py
@@ -84,6 +84,4 @@ class SelectTestCase(DaskTestCase):
 
     def test_wrong_input(self):
         self.assertRaises(ParsingException, self.c.sql, """SELECT x FROM df""")
-        self.assertRaises(
-            ParsingException, self.c.sql, """SELECT x FROM df""", debug=True
-        )
+        self.assertRaises(ParsingException, self.c.sql, """SELECT x FROM df""")


### PR DESCRIPTION
So far, the process of turning a SQL query string into a dask dataframe is somewhat "voodoo". Adding debug logging might give more useful information. 

For example doing an SQL query 
```SELECT MAX(x + y) FROM timeseries```
gives quite a lot of debug output:

```
DEBUG:dask_sql.java:Starting JVM from path /home/nils/anaconda3/envs/dask-sql-docs/lib/server/libjvm.so...
DEBUG:dask_sql.java:...having started JVM
DEBUG:dask_sql.physical.rel.convert:Registering REL plugin for org.apache.calcite.rel.logical.LogicalAggregate
DEBUG:dask_sql.physical.rel.convert:Registering REL plugin for org.apache.calcite.rel.logical.LogicalFilter
DEBUG:dask_sql.physical.rel.convert:Registering REL plugin for org.apache.calcite.rel.logical.LogicalJoin
DEBUG:dask_sql.physical.rel.convert:Registering REL plugin for org.apache.calcite.rel.logical.LogicalProject
DEBUG:dask_sql.physical.rel.convert:Registering REL plugin for org.apache.calcite.rel.logical.LogicalSort
DEBUG:dask_sql.physical.rel.convert:Registering REL plugin for org.apache.calcite.rel.logical.LogicalTableScan
DEBUG:dask_sql.physical.rel.convert:Registering REL plugin for org.apache.calcite.rel.logical.LogicalUnion
DEBUG:dask_sql.physical.rel.convert:Registering REL plugin for org.apache.calcite.rel.logical.LogicalValues
DEBUG:dask_sql.physical.rex.convert:Registering REX plugin for org.apache.calcite.rex.RexCall
DEBUG:dask_sql.physical.rex.convert:Registering REX plugin for org.apache.calcite.rex.RexInputRef
DEBUG:dask_sql.physical.rex.convert:Registering REX plugin for org.apache.calcite.rex.RexLiteral
DEBUG:dask_sql.context:Adding table 'timeseries' to schema with columns: ['timestamp', 'id', 'name', 'x', 'y']
DEBUG:dask_sql.context:No custom functions defined.
DEBUG:dask_sql.context:Using dialect: org.apache.calcite.sql.dialect.PostgresqlSqlDialect
DEBUG:dask_sql.context:Extracted relational algebra:
 LogicalAggregate(group=[{}], EXPR$0=[MAX($0)])
  LogicalProject($f0=[+($3, $4)])
    LogicalTableScan(table=[[schema, timeseries]])

DEBUG:dask_sql.physical.rel.convert:Processing REL rel#11:LogicalAggregate.NONE.[](input=LogicalProject#9,group={},EXPR$0=MAX($0)) using LogicalAggregatePlugin...
DEBUG:dask_sql.physical.rel.convert:Processing REL rel#9:LogicalProject.NONE.[](input=LogicalTableScan#4,exprs=[+($3, $4)]) using LogicalProjectPlugin...
DEBUG:dask_sql.physical.rel.convert:Processing REL rel#4:LogicalTableScan.NONE.[](table=[schema, timeseries]) using LogicalTableScanPlugin...
DEBUG:dask_sql.physical.rel.convert:Processed REL rel#4:LogicalTableScan.NONE.[](table=[schema, timeseries]) into DataFrame: [('timestamp', dtype('<M8[ns]')), ('id', dtype('int64')), ('name', dtype('O')), ('x', dtype('float64')), ('y', dtype('float64'))]
DEBUG:dask_sql.physical.rex.convert:Processing REX +($3, $4) using RexCallPlugin...
DEBUG:dask_sql.physical.rex.convert:Processing REX $3 using RexInputRefPlugin...
DEBUG:dask_sql.physical.rex.convert:Processed REX $3 into Series: ('x', dtype('float64'))
DEBUG:dask_sql.physical.rex.convert:Processing REX $4 using RexInputRefPlugin...
DEBUG:dask_sql.physical.rex.convert:Processed REX $4 into Series: ('y', dtype('float64'))
DEBUG:dask_sql.physical.rex.core.call:Executing + on ["Series: ('x', dtype('float64'))", "Series: ('y', dtype('float64'))"]
DEBUG:dask_sql.physical.rex.convert:Processed REX +($3, $4) into Series: (None, dtype('float64'))
DEBUG:dask_sql.physical.rel.logical.project:Adding a new column $f0 out of +($3, $4)
DEBUG:dask_sql.physical.rel.convert:Processed REL rel#9:LogicalProject.NONE.[](input=LogicalTableScan#4,exprs=[+($3, $4)]) into DataFrame: [('$f0', dtype('float64'))]
DEBUG:dask_sql.physical.rel.logical.aggregate:Performing full-table aggregation
DEBUG:dask_sql.physical.rel.logical.aggregate:Aggregating {'$f0': {'EXPR$0': 'max'}} on the data
DEBUG:dask_sql.physical.rel.convert:Processed REL rel#11:LogicalAggregate.NONE.[](input=LogicalProject#9,group={},EXPR$0=MAX($0)) into DataFrame: [('EXPR$0', dtype('float64'))]
```