### PR TITLE
Unify dask-sql API with blazing SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ c = Context()
 # Load the data and register it in the context
 # This will give the table a name
 df = timeseries()
-c.register_dask_table(df, "timeseries")
+c.create_table("timeseries", df)
 
 # Now execute an SQL query. The result is a dask dataframe
 # The query looks for the id with the highest x for each name

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Read more in the [documentation](https://dask-sql.readthedocs.io/en/latest/).
 
 You can try out `dask-sql` quickly by using the docker command
 
-    docker run --rm -it -p 8080:8080 nils-braun/dask-sql
+    docker run --rm -it -p 8080:8080 nbraun/dask-sql:0.1.2
 
 See information in the SQL server at the end of this page.
 
@@ -161,7 +161,7 @@ You can test the sql presto server by running
 
 or by using the created docker image
 
-    docker run --rm -it -p 8080:8080 nils-braun/dask-sql
+    docker run --rm -it -p 8080:8080 nbraun/dask-sql:0.1.2
 
 in one terminal. This will spin up a server on port 8080 (by default)
 that looks similar to a normal presto database to any presto client.

--- a/conda.yaml
+++ b/conda.yaml
@@ -8,3 +8,4 @@ pytest-cov>=2.10.1
 sphinx>=3.2.1
 fastapi>=0.61.1
 uvicorn>=0.11.3
+pyarrow>=0.15.1

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -148,7 +148,7 @@ class Context:
                 from pyhive.hive import connect
 
                 cursor = connect("localhost", 10000).cursor()
-                c.create_table("data", cursor, hive_database_name="the_name_in_hive")
+                c.create_table("data", cursor, hive_table_name="the_name_in_hive")
                 df_result = c.sql("SELECT a, b FROM data")
 
         Args:

--- a/dask_sql/input_utils.py
+++ b/dask_sql/input_utils.py
@@ -1,0 +1,218 @@
+import os
+from functools import partial
+import logging
+from typing import Union
+
+import dask.dataframe as dd
+from distributed.client import default_client
+import pandas as pd
+from pyhive import hive
+
+from dask_sql.datacontainer import DataContainer, ColumnContainer
+
+logger = logging.Logger(__name__)
+
+InputType = Union[dd.DataFrame, pd.DataFrame, str, hive.Cursor]
+
+
+def to_dc(
+    input_item: InputType,
+    file_format: str = None,
+    persist: bool = True,
+    hive_table_name: str = None,
+    hive_schema_name: str = "default",
+    **kwargs,
+) -> DataContainer:
+    """
+    Turn possible input descriptions or formats (e.g. dask dataframes, pandas dataframes,
+    locations as string, hive tables) into the loaded data containers,
+    maybe persist them to cluster memory before.
+    """
+    filled_get_dask_dataframe = lambda *args: _get_dask_dataframe(
+        *args,
+        file_format=file_format,
+        persist=persist,
+        hive_table_name=hive_table_name,
+        hive_schema_name=hive_schema_name,
+        **kwargs,
+    )
+
+    if isinstance(input_item, list):
+        table = dd.concat([filled_get_dask_dataframe(item) for item in input_item])
+    else:
+        table = filled_get_dask_dataframe(input_item)
+
+    if persist:
+        table = table.persist()
+
+    return DataContainer(table.copy(), ColumnContainer(table.columns))
+
+
+def _get_dask_dataframe(
+    input_item: InputType,
+    file_format: str = None,
+    hive_table_name: str = None,
+    hive_schema_name: str = "default",
+    persist: bool = True,
+    **kwargs,
+):
+    if isinstance(input_item, pd.DataFrame):
+        return dd.from_pandas(input_item, npartitions=1, **kwargs)
+    elif isinstance(input_item, dd.DataFrame):
+        return input_item
+    elif isinstance(input_item, hive.Cursor):  # pragma: no cover
+        return _get_files_from_hive(
+            input_item, table_name=hive_table_name, schema=hive_schema_name, **kwargs
+        )
+    elif isinstance(input_item, str):
+        return _get_files_from_location(input_item, file_format=file_format, **kwargs)
+    else:  # pragma: no cover
+        raise ValueError(f"Do not understand the input type {type(input_item)}")
+
+
+def _get_files_from_location(input_item, file_format: str = None, **kwargs):
+    if file_format == "memory":
+        client = default_client()
+        return client.get_dataset(input_item, **kwargs)
+
+    if not file_format:
+        _, extension = os.path.splitext(input_item)
+
+        file_format = extension.lstrip(".")
+
+    try:
+        read_function = getattr(dd, f"read_{file_format}")
+    except AttributeError:
+        raise AttributeError(f"Can not read files of format {file_format}")
+
+    return read_function(input_item, **kwargs)
+
+
+def _get_files_from_hive(
+    cursor: hive.Cursor, table_name: str, schema: str = "default", **kwargs
+):  # pragma: no cover
+    (
+        table_information,
+        storage_information,
+        partition_information,
+    ) = _parse_hive_table_description(cursor, schema, table_name)
+
+    if table_information["Table Type"] != "EXTERNAL_TABLE":
+        raise AssertionError("Can only read in EXTERNAL TABLES")
+
+    format = storage_information["InputFormat"].split(".")[-1]
+    storage_description = storage_information["Storage Desc Params"]
+
+    if format == "TextInputFormat":
+        read_function = partial(
+            dd.read_csv, sep=storage_description.get("field.delim", ",")
+        )
+    elif format == "ParquetInputFormat":
+        read_function = dd.read_parquet
+    elif format == "OrcInputFormat":
+        read_function = dd.read_orc
+    elif format == "JsonInputFormat":
+        read_function = dd.read_json
+    else:
+        raise AttributeError(f"Do not understand hive's table format {format}")
+
+    def _normalize(loc):
+        return os.path.join(loc.lstrip("file:"), "**")
+
+    if partition_information:
+        partition_information = _parse_hive_partition_description(
+            cursor, schema, table_name
+        )
+
+        tables = []
+        for partition in partition_information:
+            (table_information, _, _) = _parse_hive_table_description(
+                cursor, schema, table_name, partition=partition
+            )
+            location = _normalize(table_information["Location"])
+            table = read_function(location, **kwargs)
+
+            # TODO: insert partition info into dataframe?
+            tables.append(table)
+
+        return dd.concat(tables)
+
+    location = _normalize(table_information["Location"])
+    return read_function(location, **kwargs)
+
+
+def _parse_hive_table_description(
+    cursor: hive.Cursor, schema: str, table_name: str, partition: str = None
+):  # pragma: no cover
+    """
+    Extract all information from the output
+    of the DESCRIBE FORMATTED call, which is unfortunately
+    in a format not easily readable by machines.
+    """
+    cursor.execute(f"USE {schema}")
+    if partition:
+        cursor.execute(f"DESCRIBE FORMATTED {table_name} PARTITION ({partition})")
+    else:
+        cursor.execute(f"DESCRIBE FORMATTED {table_name}")
+
+    result = cursor.fetchall()
+    logger.debug(f"Got information from hive: {result}")
+
+    table_information = {}
+    storage_information = {}
+    partition_information = {}
+    mode = None
+    last_field = None
+
+    from pprint import pprint
+
+    for key, value, value2 in result:
+        key = key.strip().rstrip(":") if key else ""
+        value = value.strip() if value else ""
+        value2 = value2.strip() if value2 else ""
+
+        # That is just a comment line, we can skip it
+        if key == "# col_name":
+            continue
+
+        if (
+            key == "# Detailed Table Information"
+            or key == "# Detailed Partition Information"
+        ):
+            mode = "table"
+        elif key == "# Storage Information":
+            mode = "storage"
+        elif key == "# Partition Information":
+            mode = "partition"
+        elif key.startswith("#"):
+            mode = None
+        elif key:
+            if not value:
+                value = dict()
+            if mode == "storage":
+                storage_information[key] = value
+                last_field = storage_information[key]
+            elif mode == "table":
+                table_information[key] = value
+                last_field = table_information[key]
+            elif mode == "partition":
+                partition_information[key] = value
+                last_field = partition_information[key]
+        elif value and last_field is not None:
+            last_field[value] = value2
+
+    return table_information, storage_information, partition_information
+
+
+def _parse_hive_partition_description(
+    cursor: hive.Cursor, schema: str, table_name: str
+):  # pragma: no cover
+    """
+    Extract all partition informaton for a given table
+    """
+    cursor.execute(f"USE {schema}")
+    cursor.execute(f"SHOW PARTITIONS {table_name}")
+
+    result = cursor.fetchall()
+
+    return [row[0] for row in result]

--- a/dask_sql/input_utils.py
+++ b/dask_sql/input_utils.py
@@ -6,13 +6,17 @@ from typing import Union
 import dask.dataframe as dd
 from distributed.client import default_client
 import pandas as pd
-from pyhive import hive
+
+try:
+    from pyhive import hive
+except ImportError:
+    hive = None
 
 from dask_sql.datacontainer import DataContainer, ColumnContainer
 
 logger = logging.Logger(__name__)
 
-InputType = Union[dd.DataFrame, pd.DataFrame, str, hive.Cursor]
+InputType = Union[dd.DataFrame, pd.DataFrame, str, "hive.Cursor"]
 
 
 def to_dc(
@@ -60,7 +64,7 @@ def _get_dask_dataframe(
         return dd.from_pandas(input_item, npartitions=1, **kwargs)
     elif isinstance(input_item, dd.DataFrame):
         return input_item
-    elif isinstance(input_item, hive.Cursor):  # pragma: no cover
+    elif hive and isinstance(input_item, hive.Cursor):  # pragma: no cover
         return _get_files_from_hive(
             input_item, table_name=hive_table_name, schema=hive_schema_name, **kwargs
         )
@@ -89,7 +93,7 @@ def _get_files_from_location(input_item, file_format: str = None, **kwargs):
 
 
 def _get_files_from_hive(
-    cursor: hive.Cursor, table_name: str, schema: str = "default", **kwargs
+    cursor: "hive.Cursor", table_name: str, schema: str = "default", **kwargs
 ):  # pragma: no cover
     (
         table_information,
@@ -142,7 +146,7 @@ def _get_files_from_hive(
 
 
 def _parse_hive_table_description(
-    cursor: hive.Cursor, schema: str, table_name: str, partition: str = None
+    cursor: "hive.Cursor", schema: str, table_name: str, partition: str = None
 ):  # pragma: no cover
     """
     Extract all information from the output
@@ -205,7 +209,7 @@ def _parse_hive_table_description(
 
 
 def _parse_hive_partition_description(
-    cursor: hive.Cursor, schema: str, table_name: str
+    cursor: "hive.Cursor", schema: str, table_name: str
 ):  # pragma: no cover
     """
     Extract all partition informaton for a given table

--- a/dask_sql/java.py
+++ b/dask_sql/java.py
@@ -14,6 +14,21 @@ from dask_sql.utils import _set_or_check_java_home
 
 logger = logging.getLogger(__name__)
 
+try:  # pragma: no cover
+    # If using dask-sql together with hdfs input
+    # (e.g. via dask), we have two concurring components
+    # accessing the Java VM: the hdfs FS implementation
+    # and dask-sql. hdfs needs to have the hadoop libraries
+    # in the classpath and has a nice helper function for that
+    # Unfortunately, this classpath will not be picked up if
+    # set after the JVM is already running. So we need to make
+    # sure we call it in all circumstances before starting the
+    # JVM.
+    from pyarrow.hdfs import _maybe_set_hadoop_classpath
+
+    _maybe_set_hadoop_classpath()
+except ImportError:  # pragma: no cover
+    pass
 
 # Define how to run the java virtual machine.
 jpype.addClassPath(pkg_resources.resource_filename("dask_sql", "jar/DaskSQL.jar"))

--- a/dask_sql/java.py
+++ b/dask_sql/java.py
@@ -27,7 +27,7 @@ try:  # pragma: no cover
     from pyarrow.hdfs import _maybe_set_hadoop_classpath
 
     _maybe_set_hadoop_classpath()
-except ImportError:  # pragma: no cover
+except:  # pragma: no cover
     pass
 
 # Define how to run the java virtual machine.

--- a/dask_sql/physical/rel/custom/create.py
+++ b/dask_sql/physical/rel/custom/create.py
@@ -68,16 +68,4 @@ class CreateTablePlugin(BaseRelPlugin):
         except KeyError:
             raise AttributeError("Parameters must include a 'location' parameter.")
 
-        read_function_name = f"read_{format}"
-
-        try:
-            read_function = getattr(dd, read_function_name)
-        except AttributeError:
-            raise AttributeError(f"Do not understand input format {format}.")
-
-        df = read_function(location, **kwargs)
-
-        if persist:
-            df = df.persist()
-
-        context.create_table(table_name, df)
+        context.create_table(table_name, location, file_format=format, persist=persist)

--- a/dask_sql/physical/rel/custom/create.py
+++ b/dask_sql/physical/rel/custom/create.py
@@ -72,4 +72,3 @@ class CreateTablePlugin(BaseRelPlugin):
         context.create_table(
             table_name, location, file_format=format, persist=persist, **kwargs
         )
-

--- a/dask_sql/physical/rel/custom/create.py
+++ b/dask_sql/physical/rel/custom/create.py
@@ -80,4 +80,4 @@ class CreateTablePlugin(BaseRelPlugin):
         if persist:
             df = df.persist()
 
-        context.register_dask_table(df, table_name)
+        context.create_table(table_name, df)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,9 @@ but any other data (from disk, S3, API, hdfs) can be used.
    # (just an example, could also be done via SQL)
    print(result.x.mean().compute())
 
+The API of ``dask-sql`` is very similar to the one from `blazingsql <http://blazingsql.com/>`_,
+which makes interchanging distributed CPU and GPU calculation easy.
+
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ but any other data (from disk, S3, API, hdfs) can be used.
    # Load the data and register it in the context
    # This will give the table a name
    df = timeseries()
-   c.register_dask_table(df, "timeseries")
+   c.create_table("timeseries", df)
 
    # Now execute an SQL query. The result is a dask dataframe
    # The query looks for the id with the highest x for each name

--- a/docs/pages/data_input.rst
+++ b/docs/pages/data_input.rst
@@ -24,7 +24,36 @@ Make sure to install required libraries both on the driver and worker machines.
 
     c.create_table("my_data", df)
 
-2. Load if via SQL
+or in short (equivalent):
+
+.. code-block:: python
+
+    from dask_sql import Context
+
+    c = Context()
+
+    c.create_table("my_data", "s3://nyc-tlc/trip data/yellow_tripdata_2019-01.csv")
+
+Load hive data
+''''''''''''''
+
+As an experimental feature, it is now also possible to use data stored in the Apache Hive metastore.
+For this, ``dask-sql`` will retrieve the information on the storage location and format
+from the metastore and will then register the raw data directly in the context.
+This means, no Hive data query will be issued and you might be able to see a speed improvement.
+
+.. code-block:: python
+
+    from dask_sql import Context
+    from pyhive.hive import connect
+
+    c = Context()
+
+    cursor = connect("hive-server", 10000).cursor()
+    c.create_table("my_data", cursor, hive_table_name="the_name_in_hive")
+
+
+2. Load it via SQL
 ------------------
 
 If you are connected to the SQL server implementation or you do not want to issue python command calls, you can also

--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -47,7 +47,7 @@ Typically, you only have a single context per application.
     from dask_sql import Context
 
     c = Context()
-    c.register_dask_table(df, "timeseries")
+    c.create_table("timeseries", df)
 
 From now on, the data is accessible as the "timeseries" table of this context.
 It is possible to register multiple data frames at the same context.
@@ -60,7 +60,7 @@ It is possible to register multiple data frames at the same context.
     .. code-block:: python
 
         df = df.persist()
-        c.register_dask_table(df, "timeseries")
+        c.create_table("timeseries", df)
 
 
 3. Run your queries

--- a/docs/pages/server.rst
+++ b/docs/pages/server.rst
@@ -9,8 +9,6 @@ Instead of rebuilding a full ODBC driver, we re-use the `presto wire protocol <h
     It is - so far - only a start of the development and missing important concepts, such as
     authentication.
 
-    You need to install ``fastapi>=0.61.1`` and ``uvicorn>=0.11.3`` before running the server.
-
 You can test the sql presto server by running
 
 .. code-block:: bash
@@ -21,7 +19,7 @@ or by using the created docker image
 
 .. code-block:: bash
 
-    docker run --rm -it -p 8080:8080 nils-braun/dask-sql
+    docker run --rm -it -p 8080:8080 nbraun/dask-sql:0.1.2
 
 in one terminal. This will spin up a server on port 8080 (by default).
 The port and bind interfaces can be controlled with the ``--port`` and ``--host`` switch.
@@ -93,7 +91,7 @@ To run a standalone SQL server in your ``dask`` cluster, follow these three step
 
    .. code-block:: dockerfile
 
-        FROM nbraun/dask-sql
+        FROM nbraun/dask-sql:0.1.2
 
         COPY startup_script.py /opt/dask_sql/startup_script.py
 

--- a/docs/pages/sql.rst
+++ b/docs/pages/sql.rst
@@ -104,7 +104,7 @@ Table Creation
 --------------
 
 As described in :ref:`quickstart`, it is possible to register an already
-created dask dataframe with a call to ``c.register_dask_table``.
+created dask dataframe with a call to ``c.create_table``.
 However, it is also possible to load data directly from disk (or s3, hdfs, URL, ...)
 and register it as a table in ``dask_sql``.
 Behind the scenes, a call to one of the ``read_<format>`` of the ``dask.dataframe``

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -38,7 +38,7 @@ class DaskTestCase(TestCase):
         ]:
             df = getattr(self, df_name)
             dask_df = dd.from_pandas(df, npartitions=3)
-            self.c.register_dask_table(dask_df, df_name)
+            self.c.create_table(df_name, dask_df)
 
 
 class ComparisonTestCase(TestCase):
@@ -92,9 +92,9 @@ class ComparisonTestCase(TestCase):
         )
 
         self.c = Context()
-        self.c.register_dask_table(df1, "df1")
-        self.c.register_dask_table(df2, "df2")
-        self.c.register_dask_table(df3, "df3")
+        self.c.create_table("df1", df1)
+        self.c.create_table("df2", df2)
+        self.c.create_table("df3", df3)
 
         df1.compute().to_sql("df1", self.engine, index=False, if_exists="replace")
         df2.compute().to_sql("df2", self.engine, index=False, if_exists="replace")

--- a/tests/integration/test_complex.py
+++ b/tests/integration/test_complex.py
@@ -11,7 +11,7 @@ class TimeSeriesTestCase(TestCase):
         cls.c = Context()
 
         df = timeseries(freq="1d").persist()
-        cls.c.register_dask_table(df, "timeseries")
+        cls.c.create_table("timeseries", df)
 
     def test_complex_query(self):
         result = self.c.sql(

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -182,7 +182,7 @@ class RexOperationsTestCase(DaskTestCase):
         df["b"] = df["b"].apply(
             lambda x: pd.NA if x < 0 else x > 0, meta=("b", "bool")
         )  # turn into a bool column
-        self.c.register_dask_table(df, "df")
+        self.c.create_table("df", df)
 
         df = self.c.sql(
             """

--- a/tests/integration/test_select.py
+++ b/tests/integration/test_select.py
@@ -41,7 +41,7 @@ class SelectTestCase(DaskTestCase):
                 "float": [-1.1, np.NaN, pd.NA, np.sqrt(2)],
             }
         )
-        self.c.register_dask_table(dd.from_pandas(expected_df, npartitions=1), "df")
+        self.c.create_table("df", dd.from_pandas(expected_df, npartitions=1))
         df = self.c.sql(
             """
         SELECT *

--- a/tests/integration/test_sort.py
+++ b/tests/integration/test_sort.py
@@ -47,8 +47,8 @@ class SortTestCase(DaskTestCase):
 
     def test_sort_strings(self):
         string_table = pd.DataFrame({"a": ["zzhsd", "öfjdf", "baba"]})
-        self.c.register_dask_table(
-            dd.from_pandas(string_table, npartitions=1), "string_table"
+        self.c.create_table(
+            "string_table", dd.from_pandas(string_table, npartitions=1),
         )
 
         df = self.c.sql(

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,0 +1,64 @@
+from unittest import TestCase
+import warnings
+
+import dask.dataframe as dd
+import pandas as pd
+
+from dask_sql import Context
+
+
+class ContextTestCase(TestCase):
+    def test_add_remove_tables(self):
+        c = Context()
+
+        data_frame = dd.from_pandas(pd.DataFrame(), npartitions=1)
+
+        c.create_table("table", data_frame)
+        self.assertIn("table", c.tables)
+
+        c.drop_table("table")
+        self.assertNotIn("table", c.tables)
+
+        self.assertRaises(KeyError, c.drop_table, "table")
+
+    def test_deprecation_warning(self):
+        c = Context()
+        data_frame = dd.from_pandas(pd.DataFrame(), npartitions=1)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            c.register_dask_table(data_frame, "table")
+
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
+
+        self.assertIn("table", c.tables)
+
+        c.drop_table("table")
+        self.assertNotIn("table", c.tables)
+
+    def test_explain(self):
+        c = Context()
+
+        data_frame = dd.from_pandas(pd.DataFrame({"a": [1, 2, 3]}), npartitions=1)
+        c.create_table("df", data_frame)
+
+        sql_string = c.explain("SELECT * FROM df")
+
+        self.assertEqual(
+            sql_string,
+            "LogicalProject(a=[$0])\n  LogicalTableScan(table=[[schema, df]])\n",
+        )
+
+    def test_sql(self):
+        c = Context()
+
+        data_frame = dd.from_pandas(pd.DataFrame({"a": [1, 2, 3]}), npartitions=1)
+        c.create_table("df", data_frame)
+
+        result = c.sql("SELECT * FROM df")
+        self.assertIsInstance(result, dd.DataFrame)
+
+        result = c.sql("SELECT * FROM df", return_futures=False)
+        self.assertIsInstance(result, pd.DataFrame)

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -23,6 +23,9 @@ def test_add_remove_tables():
     with pytest.raises(KeyError):
         c.drop_table("table")
 
+    c.create_table("table", [data_frame])
+    assert "table" in c.tables
+
 
 def test_deprecation_warning():
     c = Context()

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -62,7 +62,7 @@ class ContextTestCase(TestCase):
 
         self.assertEqual(
             sql_string,
-            "LogicalProject(a=[$0])\n  LogicalTableScan(table=[[schema, df]])\n",
+            f"LogicalProject(a=[$0]){os.linesep}  LogicalTableScan(table=[[schema, df]]){os.linesep}",
         )
 
     def test_sql(self):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -3,6 +3,7 @@ import warnings
 
 import dask.dataframe as dd
 import pandas as pd
+from pandas.testing import assert_frame_equal
 
 from dask_sql import Context
 
@@ -62,3 +63,19 @@ class ContextTestCase(TestCase):
 
         result = c.sql("SELECT * FROM df", return_futures=False)
         self.assertIsInstance(result, pd.DataFrame)
+
+    def test_input_types(self):
+        c = Context()
+        df = pd.DataFrame({"a": [1, 2, 3]})
+
+        def assert_correct_output():
+            result = c.sql("SELECT * FROM df")
+            self.assertIsInstance(result, dd.DataFrame)
+            assert_frame_equal(result.compute(), df)
+
+        c.create_table("df", df)
+        assert_correct_output()
+
+        c.create_table("df", dd.from_pandas(df, npartitions=1))
+        assert_correct_output()
+


### PR DESCRIPTION
Fixes #58 

I have implemented (parts of) the blazingSQL API of the context - especially `.sql`, `.create_table`, `.explain` and `.drop_table`.

What is still missing:
- [x] let create_table also work on a hive cursor
- [ ] ~think about implementing all the file system functions (e.g. `.s3`). However - in dask they are not really needed as all the parameters can just be passed via the call to `create_table`.~ -> I decided against implementing them for now. Everything can be achieved with the methods already present. Maybe in a later step we can add them also here.