### PR TITLE
Use the default conformance level

### DIFF
--- a/planner/src/main/java/com/dask/sql/application/RelationalAlgebraGenerator.java
+++ b/planner/src/main/java/com/dask/sql/application/RelationalAlgebraGenerator.java
@@ -42,6 +42,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.util.SqlOperatorTables;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
@@ -96,8 +97,9 @@ public class RelationalAlgebraGenerator {
 		sqlOperatorTables.add(SqlLibraryOperatorTableFactory.INSTANCE.getOperatorTable(SqlLibrary.POSTGRESQL));
 		sqlOperatorTables.add(calciteCatalogReader);
 
-		SqlParser.Config parserConfig = getDialect()
-				.configureParser(SqlParser.config().withParserFactory(new DaskSqlParserImplFactory()));
+		SqlParser.Config parserConfig = getDialect().configureParser(SqlParser.Config.DEFAULT)
+				.withConformance(SqlConformanceEnum.DEFAULT).withParserFactory(new DaskSqlParserImplFactory());
+
 		SqlOperatorTable operatorTable = SqlOperatorTables.chain(sqlOperatorTables);
 
 		return Frameworks.newConfigBuilder().defaultSchema(schemaPlus).parserConfig(parserConfig)

--- a/tests/integration/test_sort.py
+++ b/tests/integration/test_sort.py
@@ -22,6 +22,22 @@ class SortTestCase(DaskTestCase):
 
         assert_frame_equal(df, df_expected)
 
+    def test_sort_by_alias(self):
+        df = self.c.sql(
+            """
+        SELECT
+            b AS my_column
+        FROM user_table_1
+        ORDER BY my_column, user_id DESC
+        """
+        )
+        df = df.compute().reset_index(drop=True).rename(columns={"my_column": "b"})
+        df_expected = self.user_table_1.sort_values(
+            ["b", "user_id"], ascending=[True, False]
+        ).reset_index(drop=True)[["b"]]
+
+        assert_frame_equal(df, df_expected)
+
     def test_sort_with_nan(self):
         self.assertRaises(
             ValueError,


### PR DESCRIPTION
which e.g. allows to reuse aliases in the query.

Now it is possible to write
```sql
SELECT a AS other
ORDER BY other
```
instead of just
```sql
SELECT a AS other
ORDER BY a
```