### PR TITLE
Allow arbitrary return types in SQL server

### DIFF
--- a/dask_sql/server/responses.py
+++ b/dask_sql/server/responses.py
@@ -95,7 +95,12 @@ class DataResults(QueryResults):
         except TypeError:  # pragma: no cover
             pass
 
-        return str(cell)
+        try:
+            return cell.item()
+        except AttributeError:
+            pass
+
+        return cell
 
     @staticmethod
     def convert_row(row):

--- a/dask_sql/server/responses.py
+++ b/dask_sql/server/responses.py
@@ -77,7 +77,9 @@ class DataResults(QueryResults):
 
     @staticmethod
     def get_data_description(df):
-        return list(df.itertuples(index=False, name=None))
+        return [
+            [str(cell) for cell in row] for row in df.itertuples(index=False, name=None)
+        ]
 
     def __init__(self, df: dd.DataFrame, request: Request):
         super().__init__(request)

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -8,44 +8,44 @@ from pandas.testing import assert_frame_equal
 import numpy as np
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def df_simple():
     return pd.DataFrame({"a": [1, 2, 3], "b": [1.1, 2.2, 3.3]})
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def df():
     return pd.DataFrame(
         {"a": [1.0] * 100 + [2.0] * 200 + [3.0] * 400, "b": 10 * np.random.rand(700),}
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def user_table_1():
     return pd.DataFrame({"user_id": [2, 1, 2, 3], "b": [3, 3, 1, 3]})
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def user_table_2():
     return pd.DataFrame({"user_id": [1, 1, 2, 4], "c": [1, 2, 3, 4]})
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def long_table():
     return pd.DataFrame({"a": [0] * 100 + [1] * 101 + [2] * 103})
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def user_table_inf():
     return pd.DataFrame({"c": [3, float("inf"), 1]})
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def user_table_nan():
     return pd.DataFrame({"c": [3, pd.NA, 1]})
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def string_table():
     return pd.DataFrame({"a": ["a normal string", "%_%", "^|()-*[]$"]})
 

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -55,7 +55,7 @@ def test_sql_query(app_client):
             "typeSignature": {"rawType": "integer", "arguments": []},
         }
     ]
-    assert result["data"] == [["2"]]
+    assert result["data"] == [[2]]
 
 
 def test_wrong_sql_query(app_client):

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -55,7 +55,7 @@ def test_sql_query(app_client):
             "typeSignature": {"rawType": "integer", "arguments": []},
         }
     ]
-    assert result["data"] == [[2]]
+    assert result["data"] == [["2"]]
 
 
 def test_wrong_sql_query(app_client):
@@ -105,6 +105,34 @@ def test_add_and_query(app_client, df, temporary_data_file):
             "name": "a",
             "type": "double",
             "typeSignature": {"rawType": "double", "arguments": []},
+        },
+        {
+            "name": "b",
+            "type": "double",
+            "typeSignature": {"rawType": "double", "arguments": []},
+        },
+    ]
+
+    assert len(result["data"]) == 700
+    assert "error" not in result
+
+
+def test_register_and_query(app_client, df):
+    df["a"] = df["a"].astype("UInt8")
+    app_client.app.c.create_table("new_table", df)
+
+    response = app_client.post("/v1/statement", data="SELECT * FROM new_table")
+    assert response.status_code == 200
+
+    result = get_result_or_error(app_client, response)
+
+    assert "columns" in result
+    assert "data" in result
+    assert result["columns"] == [
+        {
+            "name": "a",
+            "type": "tinyint",
+            "typeSignature": {"rawType": "tinyint", "arguments": []},
         },
         {
             "name": "b",

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -145,6 +145,29 @@ def test_register_and_query(app_client, df):
     assert "error" not in result
 
 
+def test_inf_table(app_client, user_table_inf):
+    app_client.app.c.create_table("new_table", user_table_inf)
+
+    response = app_client.post("/v1/statement", data="SELECT * FROM new_table")
+    assert response.status_code == 200
+
+    result = get_result_or_error(app_client, response)
+
+    assert "columns" in result
+    assert "data" in result
+    assert result["columns"] == [
+        {
+            "name": "c",
+            "type": "double",
+            "typeSignature": {"rawType": "double", "arguments": []},
+        }
+    ]
+
+    assert len(result["data"]) == 3
+    assert result["data"][1] == ["+Infinity"]
+    assert "error" not in result
+
+
 def get_result_or_error(app_client, response):
     result = response.json()
 


### PR DESCRIPTION
presto and python have slightly different ways to represent some types and values, e.g. NaN and Inf.

Additionally, the output needs to be serialized with JSON, so it needs to be in a serializable format (not numpy types).
Therefore, now all data output transformed into python objects before sending it via the presto wire protocol.