### PR TITLE
Added the ability to create (materialized) views of queries

### DIFF
--- a/dask_sql/input_utils.py
+++ b/dask_sql/input_utils.py
@@ -35,7 +35,6 @@ def to_dc(
     filled_get_dask_dataframe = lambda *args: _get_dask_dataframe(
         *args,
         file_format=file_format,
-        persist=persist,
         hive_table_name=hive_table_name,
         hive_schema_name=hive_schema_name,
         **kwargs,
@@ -57,7 +56,6 @@ def _get_dask_dataframe(
     file_format: str = None,
     hive_table_name: str = None,
     hive_schema_name: str = "default",
-    persist: bool = True,
     **kwargs,
 ):
     if isinstance(input_item, pd.DataFrame):

--- a/dask_sql/physical/rel/custom/__init__.py
+++ b/dask_sql/physical/rel/custom/__init__.py
@@ -1,9 +1,11 @@
 from .create import CreateTablePlugin
+from .create_as import CreateAsPlugin
 from .columns import ShowColumnsPlugin
 from .schemas import ShowSchemasPlugin
 from .tables import ShowTablesPlugin
 
 __all__ = [
+    CreateAsPlugin,
     CreateTablePlugin,
     ShowColumnsPlugin,
     ShowSchemasPlugin,

--- a/dask_sql/physical/rel/custom/create_as.py
+++ b/dask_sql/physical/rel/custom/create_as.py
@@ -1,0 +1,47 @@
+import logging
+
+from dask_sql.physical.rel.base import BaseRelPlugin
+from dask_sql.datacontainer import DataContainer
+from dask_sql.mappings import sql_to_python_value
+
+logger = logging.getLogger(__name__)
+
+
+class CreateAsPlugin(BaseRelPlugin):
+    """
+    Create a table or view from the given SELECT query
+    and register it at the context.
+    The SQL call looks like
+
+        CREATE TABLE <table-name> AS
+            <some select query>
+
+    It sends the select query through the normal parsing
+    and optimization and conversation before registering it.
+
+    Using this SQL is equivalent to just doing
+
+        df = context.sql("<select query>")
+        context.create_table(<table-name>, df)
+
+    but can also be used without writing a single line of code.
+    Nothing is returned.
+    """
+
+    class_name = "com.dask.sql.parser.SqlCreateTableAs"
+
+    def convert(
+        self, sql: "org.apache.calcite.sql.SqlNode", context: "dask_sql.Context"
+    ) -> DataContainer:
+        sql_select = sql.getSelect()
+        table_name = str(sql.getTableName())
+        persist = bool(sql.isPersist())
+
+        logger.debug(
+            f"Creating new table with name {table_name} and query {sql_select}"
+        )
+
+        sql_select_query = context._to_sql_string(sql_select)
+        df = context.sql(sql_select_query)
+
+        context.create_table(table_name, df, persist=persist)

--- a/docs/pages/sql.rst
+++ b/docs/pages/sql.rst
@@ -130,7 +130,7 @@ The additional parameters are passed to the call to ``read_<format>``.
 If you omit the format argument, it will be deduced from the file name extension.
 More ways to load data can be found in :ref:`data_input`.
 
-Using a similar syntax, it is also possible to create a (materialized) view of a SQL (maybe complicated) query.
+Using a similar syntax, it is also possible to create a (materialized) view of a (maybe complicated) SQL query.
 With the following command, you give the result of the ``SELECT`` query a name, that you can use
 in subsequent calls.
 

--- a/docs/pages/sql.rst
+++ b/docs/pages/sql.rst
@@ -130,6 +130,38 @@ The additional parameters are passed to the call to ``read_<format>``.
 If you omit the format argument, it will be deduced from the file name extension.
 More ways to load data can be found in :ref:`data_input`.
 
+Using a similar syntax, it is also possible to create a (materialized) view of a SQL (maybe complicated) query.
+With the following command, you give the result of the ``SELECT`` query a name, that you can use
+in subsequent calls.
+
+.. code-block:: sql
+
+    CREATE TABLE my_table AS (
+        SELECT
+            a, b, SUM(c)
+        FROM data
+        GROUP BY a, b
+        ...
+    )
+
+    SELECT * FROM my_table
+
+Instead of using ``CREATE TABLE`` it is also possible to use ``CREATE VIEW``.
+The result is very similar, the only difference is when the result will be computed: a view is recomputed on every usage,
+whereas a table is only calculated once on creation (also known as a materialized view).
+This means, if you e.g. read data from a remote file and the file changes, a query containing a view will
+be updated whereas a query with a table will stay constant.
+To update a table, you need to recreate it.
+
+.. hint::
+
+    Use views to simplify complicated queries (like a "shortcut") and tables for caching.
+
+.. note::
+
+    The update of the view only works, if your primary data source (the files you were reading in),
+    are not persisted during reading.
+
 
 Implemented operations
 ----------------------

--- a/planner/src/main/codegen/config.fmpp
+++ b/planner/src/main/codegen/config.fmpp
@@ -23,6 +23,7 @@ data: {
         "org.apache.calcite.util.*",
         "java.util.*",
         "com.dask.sql.parser.SqlCreateTable",
+        "com.dask.sql.parser.SqlCreateTableAs",
         "com.dask.sql.parser.SqlShowColumns",
         "com.dask.sql.parser.SqlShowSchemas",
         "com.dask.sql.parser.SqlShowTables"
@@ -46,6 +47,7 @@ data: {
       # List of methods for parsing custom SQL statements
       statementParserMethods: [
          "SqlCreateTable()"
+         "SqlCreateView()"
          "SqlDescribeTable()"
          "SqlShowColumns()"
          "SqlShowSchemas()"

--- a/planner/src/main/codegen/includes/parserImpls.ftl
+++ b/planner/src/main/codegen/includes/parserImpls.ftl
@@ -76,7 +76,7 @@ void KeyValueExpression(final HashMap<SqlNode, SqlNode> kwargs) :
 }
 
 // CREATE TABLE name WITH (key = value) or
-// CREATE TABLE name WITH AS
+// CREATE TABLE name AS
 SqlNode SqlCreateTable() :
 {
     final SqlParserPos pos;

--- a/planner/src/main/codegen/includes/parserImpls.ftl
+++ b/planner/src/main/codegen/includes/parserImpls.ftl
@@ -75,25 +75,66 @@ void KeyValueExpression(final HashMap<SqlNode, SqlNode> kwargs) :
     }
 }
 
-// CREATE TABLE name WITH (key = value)
+// CREATE TABLE name WITH (key = value) or
+// CREATE TABLE name WITH AS
 SqlNode SqlCreateTable() :
 {
     final SqlParserPos pos;
     final SqlIdentifier tableName;
     final HashMap<SqlNode, SqlNode> kwargs = new HashMap<SqlNode, SqlNode>();
+    final SqlSelect select;
 }
 {
     <CREATE> { pos = getPos(); } <TABLE>
     tableName = SimpleIdentifier()
-    <WITH>
-    <LPAREN>
-    KeyValueExpression(kwargs)
     (
-        <COMMA>
+        <WITH>
+        <LPAREN>
         KeyValueExpression(kwargs)
-    )*
-    <RPAREN>
+        (
+            <COMMA>
+            KeyValueExpression(kwargs)
+        )*
+        <RPAREN>
+        {
+            return new SqlCreateTable(pos, tableName, kwargs);
+        }
+    |
+        <AS>
+        (
+            <LPAREN>
+            select = SqlSelect()
+            <RPAREN>
+        |
+            select = SqlSelect()
+        )
+        {
+            // True = do make persistent
+            return new SqlCreateTableAs(pos, tableName, select, true);
+        }
+    )
+}
+
+// CREATE VIEW name AS
+SqlNode SqlCreateView() :
+{
+    final SqlParserPos pos;
+    final SqlIdentifier tableName;
+    final SqlSelect select;
+}
+{
+    <CREATE> { pos = getPos(); } <VIEW>
+    tableName = SimpleIdentifier()
+    <AS>
+    (
+        <LPAREN>
+        select = SqlSelect()
+        <RPAREN>
+    |
+        select = SqlSelect()
+    )
     {
-        return new SqlCreateTable(pos, tableName, kwargs);
+        // False = do not make persistent
+        return new SqlCreateTableAs(pos, tableName, select, false);
     }
 }

--- a/planner/src/main/java/com/dask/sql/parser/SqlCreateTableAs.java
+++ b/planner/src/main/java/com/dask/sql/parser/SqlCreateTableAs.java
@@ -1,0 +1,62 @@
+package com.dask.sql.parser;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+public class SqlCreateTableAs extends SqlCall {
+    final SqlIdentifier tableName;
+    final SqlSelect select;
+    final boolean persist;
+
+    public SqlCreateTableAs(final SqlParserPos pos, final SqlIdentifier tableName, final SqlSelect select,
+            final boolean persist) {
+        super(pos);
+        this.tableName = tableName;
+        this.select = select;
+        this.persist = persist;
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        writer.keyword("CREATE");
+        if (this.persist) {
+            writer.keyword("TABLE");
+        } else {
+            writer.keyword("VIEW");
+        }
+        this.tableName.unparse(writer, leftPrec, rightPrec);
+        writer.keyword("AS");
+        this.select.unparse(writer, leftPrec, rightPrec);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        throw new UnsupportedOperationException();
+    }
+
+    public SqlIdentifier getTableName() {
+        return this.tableName;
+    }
+
+    public SqlSelect getSelect() {
+        return this.select;
+    }
+
+    public boolean isPersist() {
+        return this.persist;
+    }
+}

--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -186,4 +186,3 @@ def test_view_table_persist(c, temporary_data_file, df):
     assert_frame_equal(
         c.sql("SELECT c FROM count_table").compute(), pd.DataFrame({"c": [700]})
     )
-

--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -1,5 +1,6 @@
 import pytest
 import dask.dataframe as dd
+import pandas as pd
 from pandas.testing import assert_frame_equal
 
 
@@ -64,13 +65,13 @@ def test_create_from_csv_persist(c, df, temporary_data_file):
     """
     )
 
-    df = c.sql(
+    return_df = c.sql(
         """
         SELECT * FROM new_table
     """
     ).compute()
 
-    assert_frame_equal(df, df)
+    assert_frame_equal(df, return_df)
 
 
 def test_wrong_create(c):
@@ -96,3 +97,93 @@ def test_wrong_create(c):
             )
         """
         )
+
+
+def test_create_from_query(c, df):
+    c.sql(
+        f"""
+        CREATE TABLE
+            new_table
+        AS (
+            SELECT * FROM df
+        )
+    """
+    )
+
+    return_df = c.sql(
+        """
+        SELECT * FROM new_table
+    """
+    ).compute()
+
+    assert_frame_equal(df, return_df)
+
+    c.sql(
+        f"""
+        CREATE VIEW
+            new_table
+        AS (
+            SELECT * FROM df
+        )
+    """
+    )
+
+    return_df = c.sql(
+        """
+        SELECT * FROM new_table
+    """
+    ).compute()
+
+    assert_frame_equal(df, return_df)
+
+
+def test_view_table_persist(c, temporary_data_file, df):
+    df.to_csv(temporary_data_file, index=False)
+    c.sql(
+        f"""
+        CREATE TABLE
+            new_table
+        WITH (
+            location = '{temporary_data_file}',
+            format = 'csv'
+        )
+    """
+    )
+
+    # Views should change, when the original data changes
+    # Tables should not change, when the original data changes
+    c.sql(
+        f"""
+        CREATE VIEW
+            count_view
+        AS (
+            SELECT COUNT(*) AS c FROM new_table
+        )
+    """
+    )
+    c.sql(
+        f"""
+        CREATE TABLE
+            count_table
+        AS (
+            SELECT COUNT(*) AS c FROM new_table
+        )
+    """
+    )
+
+    assert_frame_equal(
+        c.sql("SELECT c FROM count_view").compute(), pd.DataFrame({"c": [700]})
+    )
+    assert_frame_equal(
+        c.sql("SELECT c FROM count_table").compute(), pd.DataFrame({"c": [700]})
+    )
+
+    df.iloc[:10].to_csv(temporary_data_file, index=False)
+
+    assert_frame_equal(
+        c.sql("SELECT c FROM count_view").compute(), pd.DataFrame({"c": [10]})
+    )
+    assert_frame_equal(
+        c.sql("SELECT c FROM count_table").compute(), pd.DataFrame({"c": [700]})
+    )
+


### PR DESCRIPTION
This allows to do things like
```sql
    CREATE TABLE my_table AS (
        SELECT
            a, b, SUM(c)
        FROM data
        GROUP BY a, b
        ...
    )

    SELECT * FROM my_table
```

Both materialized views (tables) and normal views are implemented. 
Please note that using the SQL commands is the same as 
```python
df = context.sql("<select query>")
context.create_table(<table-name>, df)
```
so it is just some syntactic sugar (and useful for SQL server usages).