### PR TITLE
Add __version__ variable

### DIFF
--- a/dask_sql/__init__.py
+++ b/dask_sql/__init__.py
@@ -1,2 +1,6 @@
 from .context import Context
 from .server.app import run_server
+from ._version import get_version
+
+__version__ = get_version()
+

--- a/dask_sql/__init__.py
+++ b/dask_sql/__init__.py
@@ -3,4 +3,3 @@ from .server.app import run_server
 from ._version import get_version
 
 __version__ = get_version()
-

--- a/dask_sql/_version.py
+++ b/dask_sql/_version.py
@@ -1,0 +1,8 @@
+from importlib.metadata import version, PackageNotFoundError
+
+
+def get_version():
+    try:
+        return version("dask-sql")
+    except PackageNotFoundError:
+        pass


### PR DESCRIPTION
Fixes #74 .
As `dask-sql` uses version tags via git tags, we can just use the `importlib.metadata` version here.