### PR TITLE
Keep casing also with unquoted identifiers. 

### DIFF
--- a/docs/pages/sql.rst
+++ b/docs/pages/sql.rst
@@ -13,6 +13,7 @@ General
 -------
 
 Identifiers can be specified with double quotes or without quotes (if there is no ambiguity with SQL keywords).
+Casing with be kept (with or without quotes).
 
 .. code-block:: sql
 

--- a/planner/src/main/java/com/dask/sql/application/RelationalAlgebraGenerator.java
+++ b/planner/src/main/java/com/dask/sql/application/RelationalAlgebraGenerator.java
@@ -10,7 +10,7 @@ import java.util.Properties;
 import com.dask.sql.schema.DaskSchema;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
-
+import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
 import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.jdbc.CalciteSchema;
@@ -108,7 +108,11 @@ public class RelationalAlgebraGenerator {
 
 	/// Return the default dialect used
 	public SqlDialect getDialect() {
-		return PostgresqlSqlDialect.DEFAULT;
+		// This is basically PostgreSQL, but we would like to keep the casing
+		// of unquoted table identifiers, as this is what pandas/dask
+		// would also do.
+		// See https://github.com/nils-braun/dask-sql/issues/84
+		return new PostgresqlSqlDialect(PostgresqlSqlDialect.DEFAULT_CONTEXT.withUnquotedCasing(Casing.UNCHANGED));
 	}
 
 	/// Get a connection to "connect" to the database.

--- a/tests/integration/test_select.py
+++ b/tests/integration/test_select.py
@@ -81,6 +81,25 @@ def test_select_of_select(c, df):
     assert_frame_equal(result_df, expected_df)
 
 
+def test_select_of_select_with_casing(c, df):
+    result_df = c.sql(
+        """
+        SELECT AAA, aaa, aAa
+        FROM
+        (
+            SELECT a - 1 AS aAa, 2*b AS aaa, a + b AS AAA
+            FROM df
+        ) AS "inner"
+        """
+    )
+    result_df = result_df.compute()
+
+    expected_df = pd.DataFrame(
+        {"AAA": df["a"] + df["b"], "aaa": 2 * df["b"], "aAa": df["a"] - 1}
+    )
+    assert_frame_equal(result_df, expected_df)
+
+
 def test_wrong_input(c):
     with pytest.raises(ParsingException):
         c.sql("""SELECT x FROM df""")


### PR DESCRIPTION
Fixes #84.

As described in the issue, we have three possibilities to solve this. I am still in favor of this one, so I thought I just implement it.