### PR TITLE
Allow to register the same function with multiple parameter combinations

### DIFF
--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -227,7 +227,7 @@ class LogicalAggregatePlugin(BaseRelPlugin):
                 aggregation_function = self.AGGREGATION_MAPPING[aggregation_name]
             except KeyError:
                 try:
-                    aggregation_function = context.functions[aggregation_name].f
+                    aggregation_function = context.functions[aggregation_name]
                 except KeyError:  # pragma: no cover
                     raise NotImplementedError(
                         f"Aggregation function {aggregation_name} not implemented (yet)."

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -522,7 +522,7 @@ class RexCallPlugin(BaseRexPlugin):
             operation = self.OPERATION_MAPPING[operator_name]
         except KeyError:
             try:
-                operation = context.functions[operator_name].f
+                operation = context.functions[operator_name]
             except KeyError:
                 raise NotImplementedError(f"{operator_name} not (yet) implemented")
 

--- a/planner/src/main/java/com/dask/sql/schema/DaskSchema.java
+++ b/planner/src/main/java/com/dask/sql/schema/DaskSchema.java
@@ -16,6 +16,8 @@ import java.util.Set;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * A DaskSchema contains the list of all known tables and functions
@@ -32,12 +34,12 @@ public class DaskSchema implements Schema {
 	/// Mapping of tables name -> table.
 	private final Map<String, DaskTable> databaseTables;
 	/// Mapping of function name -> function
-	private final Map<String, Function> functions;
+	private final Collection<DaskFunction> functions;
 
 	/// Create a new DaskSchema with the given name
 	public DaskSchema(final String name) {
 		this.databaseTables = new HashMap<String, DaskTable>();
-		this.functions = new HashMap<String, Function>();
+		this.functions = new HashSet<DaskFunction>();
 		this.name = name;
 	}
 
@@ -48,12 +50,12 @@ public class DaskSchema implements Schema {
 
 	/// Add an already created scalar function to the list
 	public void addFunction(final DaskScalarFunction function) {
-		this.functions.put(function.getFunctionName(), function);
+		this.functions.add(function);
 	}
 
 	/// Add an already created scalar function to the list
 	public void addFunction(final DaskAggregateFunction function) {
-		this.functions.put(function.getFunctionName(), function);
+		this.functions.add(function);
 	}
 
 	/// Get the name of this schema
@@ -79,8 +81,11 @@ public class DaskSchema implements Schema {
 	@Override
 	public Collection<Function> getFunctions(final String name) {
 		final Collection<Function> functionCollection = new HashSet<Function>();
-		if (this.functions.containsKey(name)) {
-			functionCollection.add(this.functions.get(name));
+
+		for (final DaskFunction function : this.functions) {
+			if (function.getFunctionName().equals(name)) {
+				functionCollection.add((Function) function);
+			}
 		}
 		return functionCollection;
 	}
@@ -89,7 +94,10 @@ public class DaskSchema implements Schema {
 	@Override
 	public Set<String> getFunctionNames() {
 		final Set<String> functionSet = new HashSet<String>();
-		functionSet.addAll(this.functions.keySet());
+		for (final DaskFunction function : this.functions) {
+			functionSet.add(function.getFunctionName());
+		}
+
 		return functionSet;
 	}
 

--- a/tests/integration/test_function.py
+++ b/tests/integration/test_function.py
@@ -1,6 +1,7 @@
 import numpy as np
 from pandas.testing import assert_frame_equal
 import dask.dataframe as dd
+import pytest
 
 
 def test_custom_function(c, df):
@@ -20,6 +21,24 @@ def test_custom_function(c, df):
     assert_frame_equal(return_df.reset_index(drop=True), df[["a"]] ** 2)
 
 
+def test_multiple_definitions(c, df_simple):
+    def f(x):
+        return x ** 2
+
+    c.register_function(f, "f", [("x", np.float64)], np.float64)
+    c.register_function(f, "f", [("x", np.int64)], np.int64)
+
+    return_df = c.sql(
+        """
+        SELECT f(a) AS a, f(b) AS b
+        FROM df_simple
+        """
+    )
+    return_df = return_df.compute()
+
+    assert_frame_equal(return_df.reset_index(drop=True), df_simple[["a", "b"]] ** 2)
+
+
 def test_aggregate_function(c):
     fagg = dd.Aggregation("f", lambda x: x.sum(), lambda x: x.sum())
     c.register_aggregation(fagg, "fagg", [("x", np.float64)], np.float64)
@@ -33,3 +52,28 @@ def test_aggregate_function(c):
     return_df = return_df.compute()
 
     assert (return_df["test"] == return_df["S"]).all()
+
+
+def test_reregistration(c):
+    def f(x):
+        return x ** 2
+
+    # The same is fine
+    c.register_function(f, "f", [("x", np.float64)], np.float64)
+    c.register_function(f, "f", [("x", np.int64)], np.int64)
+
+    def f(x):
+        return x ** 3
+
+    # A different not
+    with pytest.raises(ValueError):
+        c.register_function(f, "f", [("x", np.float64)], np.float64)
+
+    fagg = dd.Aggregation("f", lambda x: x.sum(), lambda x: x.sum())
+    c.register_aggregation(fagg, "fagg", [("x", np.float64)], np.float64)
+    c.register_aggregation(fagg, "fagg", [("x", np.int64)], np.int64)
+
+    fagg = dd.Aggregation("f", lambda x: x.mean(), lambda x: x.mean())
+
+    with pytest.raises(ValueError):
+        c.register_aggregation(fagg, "fagg", [("x", np.float64)], np.float64)


### PR DESCRIPTION
Python is not so strict with types and very often, the same function works with e.g. both float and int as parameter.
For SQL however, this is a clear difference.
This PR allows to register the same function multiple times with different parameters, for example

```python
def f(x, y):
    return x * y

c.register_function(f, "f", [("x", np.int64), ("y", np.int64)], np.int64)
c.register_function(f, "f", [("x", np.float64), ("y", np.float64)], np.float64)
```