### PR TITLE
Refactor the hive input handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,11 +78,10 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install --file conda.yaml -c conda-forge
-      - name: Install sqlalchemy and docker pkg for postgres test
+      - name: Install sqlalchemy, pyhive and docker pkg for postgres/hive test
         shell: bash -l {0}
         run: |
-          # explicitly install docker and sqlalchemy package
-          pip install docker sqlalchemy psycopg2
+          pip install docker sqlalchemy psycopg2 pyhive
         if: matrix.os == 'ubuntu-latest'
       - name: Install Java (again) and test with pytest
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,10 +78,11 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install --file conda.yaml -c conda-forge
-      - name: Install sqlalchemy, pyhive and docker pkg for postgres/hive test
+      - name: Install sqlalchemy and docker pkg for postgres test
         shell: bash -l {0}
         run: |
-          pip install docker sqlalchemy psycopg2 pyhive
+          # explicitly install docker and sqlalchemy package
+          pip install docker sqlalchemy psycopg2
         if: matrix.os == 'ubuntu-latest'
       - name: Install Java (again) and test with pytest
         shell: bash -l {0}

--- a/dask_sql/input_utils.py
+++ b/dask_sql/input_utils.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover
 
 try:
     import sqlalchemy
-except ImportError:  # pragma: no cover
+except ImportError:
     sqlalchemy = None
 
 from dask_sql.datacontainer import DataContainer, ColumnContainer
@@ -79,7 +79,7 @@ def _get_dask_dataframe(
         return dd.from_pandas(input_item, npartitions=1, **kwargs)
     elif isinstance(input_item, dd.DataFrame):
         return input_item
-    elif is_hive_cursor or is_sqlalchemy_hive:
+    elif is_hive_cursor or is_sqlalchemy_hive:  # pragma: no cover
         return _get_files_from_hive(
             input_item, table_name=hive_table_name, schema=hive_schema_name, **kwargs
         )
@@ -112,7 +112,7 @@ def _get_files_from_hive(
     table_name: str,
     schema: str = "default",
     **kwargs,
-):
+):  # pragma: no cover
     parsed = _parse_hive_table_description(cursor, schema, table_name)
     (
         column_information,
@@ -137,27 +137,25 @@ def _get_files_from_hive(
     if "InputFormat" in storage_information:
         format = storage_information["InputFormat"].split(".")[-1]
     # databricks format is different, see https://github.com/nils-braun/dask-sql/issues/83
-    elif "InputFormat" in table_information:  # pragma: no cover
+    elif "InputFormat" in table_information:
         format = table_information["InputFormat"].split(".")[-1]
     else:
         raise RuntimeError(
             "Do not understand the output of 'DESCRIBE FORMATTED <table>'"
-        )  # pragma: no cover
+        )
 
-    if (
-        format == "TextInputFormat" or format == "SequenceFileInputFormat"
-    ):  # pragma: no cover
+    if format == "TextInputFormat" or format == "SequenceFileInputFormat":
         storage_description = storage_information.get("Storage Desc Params", {})
         read_function = partial(
             dd.read_csv, sep=storage_description.get("field.delim", ","), header=None,
         )
     elif format == "ParquetInputFormat" or format == "MapredParquetInputFormat":
         read_function = dd.read_parquet
-    elif format == "OrcInputFormat":  # pragma: no cover
+    elif format == "OrcInputFormat":
         read_function = dd.read_orc
-    elif format == "JsonInputFormat":  # pragma: no cover
+    elif format == "JsonInputFormat":
         read_function = dd.read_json
-    else:  # pragma: no cover
+    else:
         raise AttributeError(f"Do not understand hive's table format {format}")
 
     def _normalize(loc):
@@ -222,7 +220,7 @@ def _parse_hive_table_description(
     schema: str,
     table_name: str,
     partition: str = None,
-):
+):  # pragma: no cover
     """
     Extract all information from the output
     of the DESCRIBE FORMATTED call, which is unfortunately
@@ -264,7 +262,7 @@ def _parse_hive_table_description(
         elif key == "# Partition Information":
             mode = "partition"
         elif key.startswith("#"):
-            mode = None  # pragma: no cover
+            mode = None
         elif key:
             if not value:
                 value = dict()
@@ -280,8 +278,6 @@ def _parse_hive_table_description(
             elif mode == "partition":
                 partition_information[key] = value
                 last_field = partition_information[key]
-            else:  # pragma: no cover
-                pass
         elif value and last_field is not None:
             last_field[value] = value2
 
@@ -297,7 +293,7 @@ def _parse_hive_partition_description(
     cursor: Union["sqlalchemy.engine.base.Connection", "hive.Cursor"],
     schema: str,
     table_name: str,
-):
+):  # pragma: no cover
     """
     Extract all partition informaton for a given table
     """
@@ -309,7 +305,7 @@ def _parse_hive_partition_description(
 
 def _fetch_all_results(
     cursor: Union["sqlalchemy.engine.base.Connection", "hive.Cursor"], sql: str
-):
+):  # pragma: no cover
     """
     The pyhive.Cursor and the sqlalchemy connection behave slightly different.
     The former has the fetchall method on the cursor,
@@ -319,5 +315,5 @@ def _fetch_all_results(
 
     try:
         return result.fetchall()
-    except AttributeError:  # pragma: no cover
+    except AttributeError:
         return cursor.fetchall()

--- a/dask_sql/input_utils.py
+++ b/dask_sql/input_utils.py
@@ -2,6 +2,7 @@ import os
 from functools import partial
 import logging
 from typing import Union
+import ast
 
 import dask.dataframe as dd
 from distributed.client import default_client
@@ -18,6 +19,7 @@ except ImportError:
     sqlalchemy = None
 
 from dask_sql.datacontainer import DataContainer, ColumnContainer
+from dask_sql.mappings import sql_to_python_type, cast_column_type
 
 logger = logging.Logger(__name__)
 
@@ -111,54 +113,110 @@ def _get_files_from_hive(
     schema: str = "default",
     **kwargs,
 ):  # pragma: no cover
+    parsed = _parse_hive_table_description(cursor, schema, table_name)
     (
+        column_information,
         table_information,
         storage_information,
         partition_information,
-    ) = _parse_hive_table_description(cursor, schema, table_name)
+    ) = parsed
 
-    if table_information["Table Type"] != "EXTERNAL_TABLE":
-        raise AssertionError("Can only read in EXTERNAL TABLES")
+    logger.debug("Extracted hive information: ")
+    logger.debug(f"column information: {column_information}")
+    logger.debug(f"table information: {table_information}")
+    logger.debug(f"storage information: {storage_information}")
+    logger.debug(f"partition information: {partition_information}")
 
-    format = storage_information["InputFormat"].split(".")[-1]
-    storage_description = storage_information["Storage Desc Params"]
+    # Convert column information
+    column_information = {
+        col: sql_to_python_type(col_type.upper())
+        for col, col_type in column_information.items()
+    }
 
-    if format == "TextInputFormat":
-        read_function = partial(
-            dd.read_csv, sep=storage_description.get("field.delim", ",")
+    # Extract format information
+    if "InputFormat" in storage_information:
+        format = storage_information["InputFormat"].split(".")[-1]
+    # databricks format is different, see https://github.com/nils-braun/dask-sql/issues/83
+    elif "InputFormat" in table_information:
+        format = table_information["InputFormat"].split(".")[-1]
+    else:
+        raise RuntimeError(
+            "Do not understand the output of 'DESCRIBE FORMATTED <table>'"
         )
-    elif format == "ParquetInputFormat":
+
+    if format == "TextInputFormat" or format == "SequenceFileInputFormat":
+        storage_description = storage_information.get("Storage Desc Params", {})
+        read_function = partial(
+            dd.read_csv, sep=storage_description.get("field.delim", ","), header=None,
+        )
+        file_extension = "csv"
+    elif format == "ParquetInputFormat" or format == "MapredParquetInputFormat":
         read_function = dd.read_parquet
+        file_extension = "parquet"
     elif format == "OrcInputFormat":
         read_function = dd.read_orc
+        file_extension = "orc"
     elif format == "JsonInputFormat":
         read_function = dd.read_json
+        file_extension = "json"
     else:
         raise AttributeError(f"Do not understand hive's table format {format}")
 
     def _normalize(loc):
-        return os.path.join(loc.lstrip("file:"), "**")
+        return os.path.join(loc.lstrip("file:"), f"*.{file_extension}")
+
+    def wrapped_read_function(location, column_information, **kwargs):
+        location = _normalize(location)
+        logger.debug(f"Reading in hive data from {location}")
+        df = read_function(location, **kwargs)
+
+        logger.debug(f"Applying column information: {column_information}")
+        df.columns = column_information.keys()
+
+        for col, expected_type in column_information.items():
+            df = cast_column_type(df, col, expected_type)
+
+        return df
 
     if partition_information:
-        partition_information = _parse_hive_partition_description(
-            cursor, schema, table_name
-        )
+        partition_list = _parse_hive_partition_description(cursor, schema, table_name)
+        logger.debug(f"Reading in partitions from {partition_list}")
 
         tables = []
-        for partition in partition_information:
-            (table_information, _, _) = _parse_hive_table_description(
+        for partition in partition_list:
+            parsed = _parse_hive_table_description(
                 cursor, schema, table_name, partition=partition
             )
-            location = _normalize(table_information["Location"])
-            table = read_function(location, **kwargs)
+            (partition_column_information, partition_table_information, _, _,) = parsed
 
-            # TODO: insert partition info into dataframe?
+            location = partition_table_information["Location"]
+            table = wrapped_read_function(
+                location, partition_column_information, **kwargs
+            )
+
+            # Now add the additional partition columns
+            partition_values = ast.literal_eval(
+                partition_table_information["Partition Value"]
+            )
+
+            logger.debug(
+                f"Applying additional partition information as columns: {partition_information}"
+            )
+
+            partition_id = 0
+            for partition_key, partition_type in partition_information.items():
+                table[partition_key] = partition_values[partition_id]
+                table = cast_column_type(table, partition_key, partition_type)
+
+                partition_id += 1
+
             tables.append(table)
 
         return dd.concat(tables)
 
-    location = _normalize(table_information["Location"])
-    return read_function(location, **kwargs)
+    location = table_information["Location"]
+    df = wrapped_read_function(location, column_information, **kwargs)
+    return df
 
 
 def _parse_hive_table_description(
@@ -183,9 +241,10 @@ def _parse_hive_table_description(
     logger.debug(f"Got information from hive: {result}")
 
     table_information = {}
+    column_information = {}
     storage_information = {}
     partition_information = {}
-    mode = None
+    mode = "column"
     last_field = None
 
     for key, value, value2 in result:
@@ -211,7 +270,10 @@ def _parse_hive_table_description(
         elif key:
             if not value:
                 value = dict()
-            if mode == "storage":
+            if mode == "column":
+                column_information[key] = value
+                last_field = column_information[key]
+            elif mode == "storage":
                 storage_information[key] = value
                 last_field = storage_information[key]
             elif mode == "table":
@@ -223,7 +285,12 @@ def _parse_hive_table_description(
         elif value and last_field is not None:
             last_field[value] = value2
 
-    return table_information, storage_information, partition_information
+    return (
+        column_information,
+        table_information,
+        storage_information,
+        partition_information,
+    )
 
 
 def _parse_hive_partition_description(
@@ -235,7 +302,7 @@ def _parse_hive_partition_description(
     Extract all partition informaton for a given table
     """
     cursor.execute(f"USE {schema}")
-    result = _fetch_all_results(cursor, "SHOW PARTITIONS {table_name}")
+    result = _fetch_all_results(cursor, f"SHOW PARTITIONS {table_name}")
 
     return [row[0] for row in result]
 

--- a/dask_sql/input_utils.py
+++ b/dask_sql/input_utils.py
@@ -149,21 +149,17 @@ def _get_files_from_hive(
         read_function = partial(
             dd.read_csv, sep=storage_description.get("field.delim", ","), header=None,
         )
-        file_extension = "csv"
     elif format == "ParquetInputFormat" or format == "MapredParquetInputFormat":
         read_function = dd.read_parquet
-        file_extension = "parquet"
     elif format == "OrcInputFormat":
         read_function = dd.read_orc
-        file_extension = "orc"
     elif format == "JsonInputFormat":
         read_function = dd.read_json
-        file_extension = "json"
     else:
         raise AttributeError(f"Do not understand hive's table format {format}")
 
     def _normalize(loc):
-        return os.path.join(loc.lstrip("file:"), f"*.{file_extension}")
+        return os.path.join(loc.lstrip("file:"), "[A-Za-z0-9-]*")
 
     def wrapped_read_function(location, column_information, **kwargs):
         location = _normalize(location)

--- a/tests/integration/test_hive.py
+++ b/tests/integration/test_hive.py
@@ -12,6 +12,8 @@ from dask_sql.context import Context
 docker = pytest.importorskip("docker")
 sqlalchemy = pytest.importorskip("sqlalchemy")
 
+pytest.importorskip("pyhive")
+
 
 DEFAULT_CONFIG = {
     "HIVE_SITE_CONF_javax_jdo_option_ConnectionURL": "jdbc:postgresql://hive-metastore-postgresql/metastore",

--- a/tests/integration/test_hive.py
+++ b/tests/integration/test_hive.py
@@ -1,0 +1,183 @@
+import shutil
+import tempfile
+import pytest
+import time
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from dask_sql.context import Context
+
+# skip the test if the docker or sqlalchemy package is not installed
+docker = pytest.importorskip("docker")
+sqlalchemy = pytest.importorskip("sqlalchemy")
+
+
+DEFAULT_CONFIG = {
+    "HIVE_CORE_CONF_javax_jdo_option_ConnectionURL": "jdbc:postgresql://hive-metastore-postgresql/metastore",
+    "HIVE_SITE_CONF_javax_jdo_option_ConnectionURL": "jdbc:postgresql://hive-metastore-postgresql/metastore",
+    "HIVE_SITE_CONF_javax_jdo_option_ConnectionDriverName": "org.postgresql.Driver",
+    "HIVE_SITE_CONF_javax_jdo_option_ConnectionUserName": "hive",
+    "HIVE_SITE_CONF_javax_jdo_option_ConnectionPassword": "hive",
+    "HIVE_SITE_CONF_datanucleus_autoCreateSchema": "false",
+    "HIVE_SITE_CONF_hive_metastore_uris": "thrift://hive-metastore:9083",
+    "HDFS_CONF_dfs_namenode_datanode_registration_ip___hostname___check": "false",
+    "CORE_CONF_fs_defaultFS": "file:///database",
+    "CORE_CONF_hadoop_http_staticuser_user": "root",
+    "CORE_CONF_hadoop_proxyuser_hue_hosts": "*",
+    "CORE_CONF_hadoop_proxyuser_hue_groups": "*",
+    "HIVE_SITE_CONF_fs_default_name": "file:///database",
+    "CORE_CONF_fs_defaultFS": "file:///database",
+    "HIVE_SIZE_CONF_hive_metastore_warehouse_dir": "file:///database",
+}
+
+
+@pytest.fixture(scope="session")
+def hive_cursor():
+    """
+    Getting a hive setup up and running is a bit more complicated.
+    We need three running docker containers:
+    * a postgres database to store the metadata
+    * the metadata server itself
+    * and a server to answer SQL queries
+
+    They are all started one after the other to check,
+    if they are up and running.
+    We "fake" a network filesystem (instead of using hdfs),
+    by mounting a temporary folder from the host to the
+    docker container, which can be accessed both by hive
+    and the dask-sql client.
+
+    We just need to make sure, to remove all containers,
+    the network and the temporary folders correctly again.
+
+    The ideas for the docker setup are taken from the docker-compose
+    hive setup described by bde2020.
+    """
+    client = docker.from_env()
+
+    network = None
+    hive_server = None
+    hive_metastore = None
+    hive_postgres = None
+
+    tmpdir = tempfile.mkdtemp()
+    tmpdir_parted = tempfile.mkdtemp()
+
+    try:
+        network = client.networks.create("dask-sql-hive", driver="bridge")
+
+        hive_server = client.containers.create(
+            "bde2020/hive:2.3.2-postgresql-metastore",
+            hostname="hive-server",
+            network="dask-sql-hive",
+            volumes=[f"{tmpdir}:{tmpdir}"],
+            environment={**DEFAULT_CONFIG,},
+        )
+
+        hive_metastore = client.containers.create(
+            "bde2020/hive:2.3.2-postgresql-metastore",
+            hostname="hive-metastore",
+            network="dask-sql-hive",
+            environment=DEFAULT_CONFIG,
+            command="/opt/hive/bin/hive --service metastore",
+        )
+
+        hive_postgres = client.containers.create(
+            "bde2020/hive-metastore-postgresql:2.3.0",
+            hostname="hive-metastore-postgresql",
+            network="dask-sql-hive",
+        )
+
+        # Wait for it to start
+        hive_postgres.start()
+        hive_postgres.exec_run(["bash"])
+        for l in hive_postgres.logs(stream=True):
+            if b"ready for start up." in l:
+                break
+
+        hive_metastore.start()
+        hive_metastore.exec_run(["bash"])
+        for l in hive_metastore.logs(stream=True):
+            if b"Starting hive metastore" in l:
+                break
+
+        hive_server.start()
+        hive_server.exec_run(["bash"])
+        for l in hive_server.logs(stream=True):
+            if b"Starting HiveServer2" in l:
+                break
+
+        # The server needs some time to start.
+        # It is easier to check for the first access
+        # on the metastore than to wait some
+        # arbitrary time.
+        for l in hive_metastore.logs(stream=True):
+            if b"get_multi_table" in l:
+                break
+
+        time.sleep(1)
+
+        hive_server.reload()
+        address = hive_server.attrs["NetworkSettings"]["Networks"]["dask-sql-hive"][
+            "IPAddress"
+        ]
+        port = 10000
+        cursor = sqlalchemy.create_engine(f"hive://{address}:{port}").connect()
+
+        # Create a non-partitioned column
+        cursor.execute(
+            f"CREATE TABLE df (i INTEGER, j INTEGER) ROW FORMAT DELIMITED STORED AS PARQUET LOCATION '{tmpdir}'"
+        )
+        cursor.execute("INSERT INTO df (i, j) VALUES (1, 2)")
+        cursor.execute("INSERT INTO df (i, j) VALUES (2, 4)")
+
+        cursor.execute(
+            f"CREATE TABLE df (i INTEGER) PARTITIONED BY (j INTEGER) ROW FORMAT DELIMITED STORED AS PARQUET LOCATION '{tmpdir_parted}'"
+        )
+        cursor.execute("INSERT INTO df_part PARTITION (j=1) (i) VALUES (2)")
+        cursor.execute("INSERT INTO df_part PARTITION (j=2) (i) VALUES (4)")
+
+        # The data files are created as root user by default. Change that:
+        hive_server.exec_run(["chmod", "a+rwx", tmpdir])
+        hive_server.exec_run(["chmod", "a+rwx", tmpdir_parted])
+
+        yield cursor
+    finally:
+        # Now clean up: remove the containers and the network and the folders
+        for container in [hive_server, hive_metastore, hive_postgres]:
+            if container is None:
+                continue
+
+            try:
+                container.kill()
+            except:
+                pass
+
+            container.remove()
+
+        if network is not None:
+            network.remove()
+
+        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmpdir_parted)
+
+
+def test_select(hive_cursor):
+    c = Context()
+    c.create_table("df", hive_cursor)
+
+    result_df = c.sql("SELECT * FROM df").compute().reset_index(drop=True)
+    df = pd.DataFrame({"i": [1, 2], "j": [2, 4]}).astype("int32")
+
+    assert_frame_equal(df, result_df)
+
+
+def test_select_partitions(hive_cursor):
+    c = Context()
+    c.create_table("df_part", hive_cursor)
+
+    result_df = c.sql("SELECT * FROM df_part").compute().reset_index(drop=True)
+    df = pd.DataFrame({"i": [1, 2], "j": [2, 4]}).astype("int32")
+
+    assert_frame_equal(df, result_df)

--- a/tests/integration/test_postgres.py
+++ b/tests/integration/test_postgres.py
@@ -2,8 +2,7 @@ import pytest
 
 # skip the test if the docker package is not installed
 docker = pytest.importorskip("docker")
-
-from sqlalchemy import create_engine
+sqlalchemy = pytest.importorskip("sqlalchemy")
 
 
 @pytest.fixture(scope="session")
@@ -35,7 +34,7 @@ def engine():
         address = postgres.attrs["NetworkSettings"]["Networks"]["dask-sql"]["IPAddress"]
         port = 5432
 
-        engine = create_engine(
+        engine = sqlalchemy.create_engine(
             f"postgresql+psycopg2://postgres@{address}:{port}/postgres"
         )
         yield engine


### PR DESCRIPTION
* Add the column information from hive, not from file
* Better support for databricks tables (although still not working)
* Add the partition information as columns
* do not read in _success files etc
* add debugging info
* added a test using a hive docker image

This should be a first step towards #83.
When I now create a databricks table with 
```python
import pandas as pd
d = {'col1': [1, 2], 'col2': [3, 4]}
pdf = pd.DataFrame(data=d)

df = spark.createDataFrame(pdf)
df.write.format("csv").saveAsTable("tmp.df")
```

I "at least" only end up with "dbfs:/user/hive/warehouse/tmp.db/df2/*.csv resolved to no files".
When the `dbfs` is integrated as additional fs, that might already do the trick.