### PR TITLE
Limit pandas version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,8 @@ jobs:
         shell: bash -l {0}
         run: |
           # explicitly install docker and sqlalchemy package
-          pip install docker sqlalchemy psycopg2
+          conda install sqlalchemy psycopg2 -c conda-forge
+          pip install docker
         if: matrix.os == 'ubuntu-latest'
       - name: Install Java (again) and test with pytest
         shell: bash -l {0}

--- a/conda.yaml
+++ b/conda.yaml
@@ -1,5 +1,8 @@
 python>=3.8.5
 dask>=2.19.0
+pandas<1.2.0 # pandas 1.2.0 introduced float NaN dtype,
+             # which is currently not working with postgres,
+             # so the test is failing
 jpype1>=1.0.2
 openjdk>=11
 maven>=3.6.0

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,9 @@ setup(
     setup_requires=["setuptools_scm"] + sphinx_requirements,
     install_requires=[
         "dask[dataframe]>=2.19.0",
+        "pandas<1.2.0",  # pandas 1.2.0 introduced float NaN dtype,
+        # which is currently not working with postgres,
+        # so the test is failing
         "jpype1>=1.0.2",
         "fastapi>=0.61.1",
         "uvicorn>=0.11.3",
@@ -84,6 +87,13 @@ setup(
         ]
     },
     zip_safe=False,
-    cmdclass={"java": MavenCommand, "build_py": BuildPyCommand,},
-    command_options={"build_sphinx": {"source_dir": ("setup.py", "docs"),}},
+    cmdclass={
+        "java": MavenCommand,
+        "build_py": BuildPyCommand,
+    },
+    command_options={
+        "build_sphinx": {
+            "source_dir": ("setup.py", "docs"),
+        }
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -87,13 +87,6 @@ setup(
         ]
     },
     zip_safe=False,
-    cmdclass={
-        "java": MavenCommand,
-        "build_py": BuildPyCommand,
-    },
-    command_options={
-        "build_sphinx": {
-            "source_dir": ("setup.py", "docs"),
-        }
-    },
+    cmdclass={"java": MavenCommand, "build_py": BuildPyCommand,},
+    command_options={"build_sphinx": {"source_dir": ("setup.py", "docs"),}},
 )


### PR DESCRIPTION
Fixing the build failure seen in #98 

pandas version 1.2.0 introduced float nan dtype.
It seems, this is currently not correctly supported in the sqlalchemy
postgres intregration (or at least in the way the integration test
is using it). Therefore the test is failing.
As long as this is not understood, I just deactivate this version.