### PR TITLE
Add datetime[ns, UTC] as understood type

### DIFF
--- a/dask_sql/mappings.py
+++ b/dask_sql/mappings.py
@@ -83,6 +83,9 @@ def python_to_sql_type(python_type):
     if isinstance(python_type, np.dtype):
         python_type = python_type.type
 
+    if pd.api.types.is_datetime64tz_dtype(python_type):
+        return SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+
     try:
         return _PYTHON_TO_SQL[python_type]
     except KeyError:  # pragma: no cover
@@ -189,6 +192,10 @@ def sql_to_python_type(sql_type: str) -> type:
         return np.dtype("<m8[ns]")
     elif sql_type.startswith("TIMESTAMP(") or sql_type.startswith("TIME("):
         return np.dtype("<M8[ns]")
+    elif sql_type.startswith("TIMESTAMP_WITH_LOCAL_TIME_ZONE("):
+        # Everything is converted to UTC
+        # So far, this did not break
+        return pd.DatetimeTZDtype(unit="ns", tz="UTC")
     elif sql_type.startswith("DECIMAL("):
         # We use np.float64 always, even though we might
         # be able to use a smaller type

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -51,6 +51,21 @@ def string_table():
 
 
 @pytest.fixture()
+def datetime_table():
+    return pd.DataFrame(
+        {
+            "timezone": pd.date_range(
+                start="2014-08-01 09:00", freq="H", periods=3, tz="Europe/Berlin"
+            ),
+            "no_timezone": pd.date_range(start="2014-08-01 09:00", freq="H", periods=3),
+            "utc_timezone": pd.date_range(
+                start="2014-08-01 09:00", freq="H", periods=3, tz="UTC"
+            ),
+        }
+    )
+
+
+@pytest.fixture()
 def c(
     df_simple,
     df,
@@ -60,6 +75,7 @@ def c(
     user_table_inf,
     user_table_nan,
     string_table,
+    datetime_table,
 ):
     dfs = {
         "df_simple": df_simple,
@@ -70,6 +86,7 @@ def c(
         "user_table_inf": user_table_inf,
         "user_table_nan": user_table_nan,
         "string_table": string_table,
+        "datetime_table": datetime_table,
     }
 
     # Lazy import, otherwise the pytest framework has problems

--- a/tests/integration/test_select.py
+++ b/tests/integration/test_select.py
@@ -106,3 +106,14 @@ def test_wrong_input(c):
 
     with pytest.raises(ParsingException):
         c.sql("""SELECT x FROM df""")
+
+
+def test_timezones(c, datetime_table):
+    result_df = c.sql(
+        """
+        SELECT * FROM datetime_table
+        """
+    )
+    result_df = result_df.compute()
+
+    assert_frame_equal(result_df, datetime_table)

--- a/tests/integration/test_show.py
+++ b/tests/integration/test_show.py
@@ -35,6 +35,7 @@ def test_tables(c):
                 "user_table_inf",
                 "user_table_nan",
                 "string_table",
+                "datetime_table",
             ]
         }
     )

--- a/tests/unit/test_mapping.py
+++ b/tests/unit/test_mapping.py
@@ -9,6 +9,10 @@ from dask_sql.mappings import python_to_sql_type, sql_to_python_value, similar_t
 def test_python_to_sql():
     assert str(python_to_sql_type(np.dtype("int32"))) == "INTEGER"
     assert str(python_to_sql_type(np.dtype(">M8[ns]"))) == "TIMESTAMP"
+    assert (
+        str(python_to_sql_type(pd.DatetimeTZDtype(unit="ns", tz="UTC")))
+        == "TIMESTAMP_WITH_LOCAL_TIME_ZONE"
+    )
 
 
 def test_sql_to_python():


### PR DESCRIPTION
Fixes #102

Timezone aware types are still a bit "underrepresented" in dask-sql... This PR at least fixes the issue, but there might be more things to check for in the future