### PR TITLE
Column container copies

### DIFF
--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -41,7 +41,9 @@ class ColumnContainer:
         """
         Internal function to copy this container
         """
-        return ColumnContainer(self._frontend_columns, self._frontend_backend_mapping)
+        return ColumnContainer(
+            self._frontend_columns.copy(), self._frontend_backend_mapping.copy()
+        )
 
     def limit_to(self, fields: List[str]) -> ColumnContainer:
         """
@@ -87,7 +89,7 @@ class ColumnContainer:
         """
         The stored frontend columns in the correct order
         """
-        return self._frontend_columns
+        return self._frontend_columns.copy()
 
     def add(
         self, frontend_column: str, backend_column: Union[str, None] = None
@@ -104,7 +106,8 @@ class ColumnContainer:
         cc._frontend_backend_mapping[frontend_column] = str(
             backend_column or frontend_column
         )
-        cc._frontend_columns.append(frontend_column)
+        if frontend_column not in cc._frontend_columns:
+            cc._frontend_columns.append(frontend_column)
 
         return cc
 

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -2,11 +2,11 @@ import operator
 from collections import defaultdict
 from functools import reduce
 from typing import Callable, Dict, List, Tuple, Union
-import uuid
 import logging
 
 import dask.dataframe as dd
 
+from dask_sql.utils import new_temporary_column
 from dask_sql.physical.rel.base import BaseRelPlugin
 from dask_sql.datacontainer import DataContainer, ColumnContainer
 
@@ -111,7 +111,7 @@ class LogicalAggregatePlugin(BaseRelPlugin):
         ]
 
         # Always keep an additional column around for empty groups and aggregates
-        additional_column_name = str(uuid.uuid4())
+        additional_column_name = new_temporary_column(df)
 
         # NOTE: it might be the case that
         # we do not need this additional

--- a/dask_sql/physical/rel/logical/project.py
+++ b/dask_sql/physical/rel/logical/project.py
@@ -1,4 +1,6 @@
+from dask_sql.utils import new_temporary_column
 import logging
+from uuid import uuid4
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rex.core.input_ref import RexInputRefPlugin
@@ -47,10 +49,12 @@ class LogicalProjectPlugin(BaseRelPlugin):
                 )
                 new_mappings[key] = backend_column_name
             else:
-                new_columns[key] = RexConverter.convert(expr, dc, context=context)
+                random_name = new_temporary_column(df)
+                new_columns[random_name] = RexConverter.convert(
+                    expr, dc, context=context
+                )
                 logger.debug(f"Adding a new column {key} out of {expr}")
-                cc = cc.add(key, key)
-                new_mappings[key] = key
+                new_mappings[key] = random_name
 
         # Actually add the new columns
         if new_columns:

--- a/dask_sql/utils.py
+++ b/dask_sql/utils.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import re
 from datetime import datetime
 import logging
+from uuid import uuid4
 
 import dask.dataframe as dd
 import numpy as np
@@ -262,3 +263,12 @@ def import_class(name: str) -> type:
     module_path, class_name = name.rsplit(".", 1)
     module = importlib.import_module(module_path)
     return getattr(module, class_name)
+
+
+def new_temporary_column(df: dd.DataFrame) -> str:
+    """Return a new column name which is currently not in use"""
+    while True:
+        col_name = str(uuid4())
+
+        if col_name not in df.columns:
+            return col_name

--- a/dask_sql/utils.py
+++ b/dask_sql/utils.py
@@ -272,3 +272,5 @@ def new_temporary_column(df: dd.DataFrame) -> str:
 
         if col_name not in df.columns:
             return col_name
+        else:  # pragma: no cover
+            continue

--- a/tests/unit/test_datacontainer.py
+++ b/tests/unit/test_datacontainer.py
@@ -1,0 +1,67 @@
+from dask_sql.datacontainer import ColumnContainer, DataContainer
+
+
+def test_cc_init():
+    c = ColumnContainer(["a", "b", "c"])
+
+    assert c.columns == ["a", "b", "c"]
+    assert c.mapping() == [("a", "a"), ("b", "b"), ("c", "c")]
+
+    c = ColumnContainer(["a", "b", "c"], {"a": "1", "b": "2", "c": "3"})
+
+    assert c.columns == ["a", "b", "c"]
+    assert c.mapping() == [("a", "1"), ("b", "2"), ("c", "3")]
+
+
+def test_cc_limit_to():
+    c = ColumnContainer(["a", "b", "c"])
+
+    c2 = c.limit_to(["c", "a"])
+
+    assert c2.columns == ["c", "a"]
+    assert c2.mapping() == [("a", "a"), ("b", "b"), ("c", "c")]
+    assert c.columns == ["a", "b", "c"]
+    assert c.mapping() == [("a", "a"), ("b", "b"), ("c", "c")]
+
+
+def test_cc_rename():
+    c = ColumnContainer(["a", "b", "c"])
+
+    c2 = c.rename({"a": "A", "b": "a"})
+
+    assert c2.columns == ["A", "a", "c"]
+    assert c2.mapping() == [("a", "b"), ("b", "b"), ("c", "c"), ("A", "a")]
+    assert c.columns == ["a", "b", "c"]
+    assert c.mapping() == [("a", "a"), ("b", "b"), ("c", "c")]
+
+
+def test_cc_add():
+    c = ColumnContainer(["a", "b", "c"])
+
+    c2 = c.add("d")
+
+    assert c2.columns == ["a", "b", "c", "d"]
+    assert c2.mapping() == [("a", "a"), ("b", "b"), ("c", "c"), ("d", "d")]
+    assert c.columns == ["a", "b", "c"]
+    assert c.mapping() == [("a", "a"), ("b", "b"), ("c", "c")]
+
+    c2 = c.add("d", "D")
+
+    assert c2.columns == ["a", "b", "c", "d"]
+    assert c2.mapping() == [("a", "a"), ("b", "b"), ("c", "c"), ("d", "D")]
+    assert c.columns == ["a", "b", "c"]
+    assert c.mapping() == [("a", "a"), ("b", "b"), ("c", "c")]
+
+    c2 = c.add("d", "a")
+
+    assert c2.columns == ["a", "b", "c", "d"]
+    assert c2.mapping() == [("a", "a"), ("b", "b"), ("c", "c"), ("d", "a")]
+    assert c.columns == ["a", "b", "c"]
+    assert c.mapping() == [("a", "a"), ("b", "b"), ("c", "c")]
+
+    c2 = c.add("a", "b")
+
+    assert c2.columns == ["a", "b", "c"]
+    assert c2.mapping() == [("a", "b"), ("b", "b"), ("c", "c")]
+    assert c.columns == ["a", "b", "c"]
+    assert c.mapping() == [("a", "a"), ("b", "b"), ("c", "c")]


### PR DESCRIPTION
In some rare SQL statements, when the same dataframe is referenced multiple times, it might happen that the column container is not copied when changed, but actually changed in place. That is a bug, as the column container should be immutable (especially the one stored in the context table list).
This PR adds a test and a fix for this.

Additionally, I added a new method to create temporary column names (which is used in these cases) and fixed the project step to no overwrite already present columns, which is especially needed if referencing the same column name in multiple project steps (e.g. in complicated multistep SQLs, as the one in the new test)