### PR TITLE
Average decimal type

### DIFF
--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -697,7 +697,7 @@ class RexCallPlugin(BaseRexPlugin):
         except KeyError:
             try:
                 operation = context.functions[operator_name]
-            except KeyError:
+            except KeyError:  # pragma: no cover
                 raise NotImplementedError(f"{operator_name} not (yet) implemented")
 
         logger.debug(

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -616,6 +616,7 @@ class RexCallPlugin(BaseRexPlugin):
         "/": ReduceOperation(operation=SQLDivisionOperator()),
         "*": ReduceOperation(operation=operator.mul),
         # special operations
+        "cast": lambda x: x,
         "case": CaseOperation(),
         "like": LikeOperation(),
         "similar to": SimilarOperation(),

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -1,3 +1,4 @@
+from dask_sql.mappings import sql_to_python_type
 import operator
 from functools import reduce
 from typing import Any, Union, Callable
@@ -29,6 +30,17 @@ class Operation:
     # True, if the operation should also get the dataframe passed
     needs_dc = False
 
+    # True, if the operation should also get the REX
+    needs_rex = False
+
+    @staticmethod
+    def op_needs_dc(op):
+        return hasattr(op, "needs_dc") and op.needs_dc
+
+    @staticmethod
+    def op_needs_rex(op):
+        return hasattr(op, "needs_rex") and op.needs_rex
+
     def __init__(self, f: Callable):
         """Init with the given function"""
         self.f = f
@@ -39,7 +51,11 @@ class Operation:
 
     def of(self, op: "Operation") -> "Operation":
         """Functional composition"""
-        return Operation(lambda x: self(op(x)))
+        new_op = Operation(lambda x: self(op(x)))
+        new_op.needs_dc = Operation.op_needs_dc(op)
+        new_op.needs_rex = Operation.op_needs_rex(op)
+
+        return new_op
 
 
 class PredicateBasedOperation(Operation):
@@ -79,8 +95,16 @@ class ReduceOperation(Operation):
 
     def __init__(self, operation: Callable):
         self.operation = operation
+        self.needs_dc = Operation.op_needs_dc(self.operation)
+        self.needs_rex = Operation.op_needs_rex(self.operation)
 
-        super().__init__(lambda *operands: reduce(self.operation, operands))
+        super().__init__(self.reduce)
+
+    def reduce(self, *operands, **kwargs):
+        enriched_with_kwargs = lambda kwargs: (
+            lambda x, y: self.operation(x, y, **kwargs)
+        )
+        return reduce(enriched_with_kwargs(kwargs), operands)
 
 
 class SQLDivisionOperator(Operation):
@@ -92,15 +116,19 @@ class SQLDivisionOperator(Operation):
     (where -1/2 = -1), but truncated division (so -1 / 2 = 0).
     """
 
+    needs_rex = True
+
     def __init__(self):
         super().__init__(self.div)
 
-    def div(self, lhs, rhs):
+    def div(self, lhs, rhs, rex=None):
         result = lhs / rhs
 
-        lhs_float = pd.api.types.is_float_dtype(lhs)
-        rhs_float = pd.api.types.is_float_dtype(rhs)
-        if not lhs_float and not rhs_float:
+        output_type = str(rex.getType())
+        output_type = sql_to_python_type(output_type.upper())
+
+        is_float = pd.api.types.is_float_dtype(output_type)
+        if not is_float:
             result = da.trunc(result)
 
         return result
@@ -674,9 +702,14 @@ class RexCallPlugin(BaseRexPlugin):
         logger.debug(
             f"Executing {operator_name} on {[str(LoggableDataFrame(df)) for df in operands]}"
         )
-        if hasattr(operation, "needs_dc") and operation.needs_dc:
-            return operation(*operands, dc=dc)
-        else:
-            return operation(*operands)
+
+        kwargs = {}
+
+        if Operation.op_needs_dc(operation):
+            kwargs["dc"] = dc
+        if Operation.op_needs_rex(operation):
+            kwargs["rex"] = rex
+
+        return operation(*operands, **kwargs)
 
         # TODO: We have information on the typing here - we should use it

--- a/planner/src/main/java/com/dask/sql/application/DaskSqlDialect.java
+++ b/planner/src/main/java/com/dask/sql/application/DaskSqlDialect.java
@@ -1,0 +1,33 @@
+package com.dask.sql.application;
+
+import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+public class DaskSqlDialect {
+    public static final RelDataTypeSystem DASKSQL_TYPE_SYSTEM = new RelDataTypeSystemImpl() {
+        @Override
+        public int getMaxPrecision(SqlTypeName typeName) {
+            return PostgresqlSqlDialect.POSTGRESQL_TYPE_SYSTEM.getMaxPrecision(typeName);
+        }
+
+        @Override
+        public RelDataType deriveAvgAggType(RelDataTypeFactory typeFactory, RelDataType argumentType) {
+            return typeFactory.decimalOf(argumentType);
+        }
+    };
+
+    public static final SqlDialect.Context DEFAULT_CONTEXT = PostgresqlSqlDialect.DEFAULT_CONTEXT
+            .withUnquotedCasing(Casing.UNCHANGED).withDataTypeSystem(DASKSQL_TYPE_SYSTEM);
+
+    // This is basically PostgreSQL, but we would like to keep the casing
+    // of unquoted table identifiers, as this is what pandas/dask
+    // would also do.
+    // See https://github.com/nils-braun/dask-sql/issues/84
+    public static final SqlDialect DEFAULT = new PostgresqlSqlDialect(DEFAULT_CONTEXT);
+}

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -127,7 +127,8 @@ def test_aggregations(c):
         BIT_AND(b) AS b,
         BIT_OR(b) AS bb,
         MIN(b) AS m,
-        SINGLE_VALUE(b) AS s
+        SINGLE_VALUE(b) AS s,
+        AVG(b) AS a
     FROM user_table_1
     GROUP BY user_id
     """
@@ -142,6 +143,37 @@ def test_aggregations(c):
             "bb": [3, 3, 3],
             "m": [3, 1, 3],
             "s": [3, 3, 3],
+            "a": [3, 2, 3],
+        }
+    )
+    expected_df["a"] = expected_df["a"].astype("float64")
+    assert_frame_equal(df.sort_values("user_id").reset_index(drop=True), expected_df)
+
+    df = c.sql(
+        """
+    SELECT
+        user_id,
+        EVERY(c = 3) AS e,
+        BIT_AND(c) AS b,
+        BIT_OR(c) AS bb,
+        MIN(c) AS m,
+        SINGLE_VALUE(c) AS s,
+        AVG(c) AS a
+    FROM user_table_2
+    GROUP BY user_id
+    """
+    )
+    df = df.compute()
+
+    expected_df = pd.DataFrame(
+        {
+            "user_id": [1, 2, 4],
+            "e": [False, True, False],
+            "b": [0, 3, 4],
+            "bb": [3, 3, 4],
+            "m": [1, 3, 4],
+            "s": [1, 3, 4],
+            "a": [1.5, 3, 4],
         }
     )
     assert_frame_equal(df.sort_values("user_id").reset_index(drop=True), expected_df)

--- a/tests/integration/test_join.py
+++ b/tests/integration/test_join.py
@@ -93,13 +93,6 @@ def test_join_right(c):
     )
 
 
-def test_join_strange(c):
-    with pytest.raises(NotImplementedError):
-        c.sql(
-            "SELECT lhs.a, rhs.b FROM df_simple AS lhs JOIN df_simple AS rhs ON lhs.a = 3",
-        )
-
-
 def test_join_complex(c):
     df = c.sql(
         "SELECT lhs.a, rhs.b FROM df_simple AS lhs JOIN df_simple AS rhs ON lhs.a < rhs.b",


### PR DESCRIPTION
When averaging over an integer column, dask (and also many SQL engines) produce a float - unfortunately the default implementation of Calcite will not do that. This PR fixes this.
Also, the division needed to be fixed for this.
This PR also brings a preliminary implementation for `CAST`, which is so far only an identity (as the type conversion is already handled by the mapping in the Rel converter base functions)