### PR TITLE
Importlib import

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install --file conda.yaml -c conda-forge
-          conda install python=${{ matrix.python }}
+          conda install python=${{ matrix.python }} --file conda.yaml -c conda-forge
       - name: Install sqlalchemy and docker pkg for postgres test
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,13 +48,14 @@ jobs:
           path: dask_sql/jar/DaskSQL.jar
 
   test:
-    name: "Test (${{ matrix.os }}, java: ${{ matrix.java }})"
+    name: "Test (${{ matrix.os }}, java: ${{ matrix.java }}, python: ${{ matrix.python }})"
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         java: [8, 11]
         os: [ubuntu-latest, windows-latest]
+        python: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository
@@ -78,6 +79,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install --file conda.yaml -c conda-forge
+          conda install python=${{ matrix.python }}
       - name: Install sqlalchemy and docker pkg for postgres test
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         java: [8, 11]
         os: [ubuntu-latest, windows-latest]
-        python: [3.7, 3.8, 3.9]
+        python: [3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository

--- a/conda.yaml
+++ b/conda.yaml
@@ -1,4 +1,4 @@
-python>=3.8.5
+python>=3.7
 dask>=2.19.0
 pandas<1.2.0 # pandas 1.2.0 introduced float NaN dtype,
              # which is currently not working with postgres,

--- a/dask_sql/_version.py
+++ b/dask_sql/_version.py
@@ -1,8 +1,11 @@
-from importlib.metadata import version, PackageNotFoundError
+try:
+    from importlib import metadata
+except ImportError:  # for Python < 3.8
+    import importlib_metadata as metadata
 
 
 def get_version():
     try:
-        return version("dask-sql")
-    except PackageNotFoundError:  # pragma: no cover
+        return metadata.version("dask-sql")
+    except metadata.PackageNotFoundError:  # pragma: no cover
         pass

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,8 @@ setup(
         "tzlocal>=2.1",
         "prompt_toolkit",
         "pygments",
+        # backport for python versions without importlib.metadata
+        "importlib_metadata; python_version < '3.8.0'",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Fixes #124.
In python < 3.8, the `importlib.metadata` was not already present. However, there is a backport in the module `importlib_metadata`. This one needs to be installed and used for earlier python versions.

I have also added a test for python 3.7, 3.8 and 3.9 - just to be sure it always works.