### PR TITLE
Correctly sort NULLs

### DIFF
--- a/dask_sql/physical/rel/logical/sort.py
+++ b/dask_sql/physical/rel/logical/sort.py
@@ -1,13 +1,13 @@
+from dask_sql.utils import new_temporary_column
 from typing import List
 
 import dask
 import dask.dataframe as dd
-import pandas as pd
-import dask.array as da
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rel.base import BaseRelPlugin
 from dask_sql.datacontainer import DataContainer
+from dask_sql.java import org
 
 
 class LogicalSortPlugin(BaseRelPlugin):
@@ -31,7 +31,14 @@ class LogicalSortPlugin(BaseRelPlugin):
             cc.get_backend_by_frontend_index(int(x.getFieldIndex()))
             for x in sort_collation
         ]
-        sort_ascending = [str(x.getDirection()) == "ASCENDING" for x in sort_collation]
+
+        if sort_columns:
+            ASCENDING = org.apache.calcite.rel.RelFieldCollation.Direction.ASCENDING
+            FIRST = org.apache.calcite.rel.RelFieldCollation.NullDirection.FIRST
+            sort_ascending = [x.getDirection() == ASCENDING for x in sort_collation]
+            sort_null_first = [x.nullDirection == FIRST for x in sort_collation]
+
+            df = self._apply_sort(df, sort_columns, sort_ascending, sort_null_first)
 
         offset = rel.offset
         if offset:
@@ -44,9 +51,6 @@ class LogicalSortPlugin(BaseRelPlugin):
             if offset:
                 end += offset
 
-        if sort_columns:
-            df = self._apply_sort(df, sort_columns, sort_ascending)
-
         if offset is not None or end is not None:
             df = self._apply_offset(df, offset, end)
 
@@ -55,36 +59,109 @@ class LogicalSortPlugin(BaseRelPlugin):
         return DataContainer(df, cc)
 
     def _apply_sort(
-        self, df: dd.DataFrame, sort_columns: List[str], sort_ascending: List[bool]
+        self,
+        df: dd.DataFrame,
+        sort_columns: List[str],
+        sort_ascending: List[bool],
+        sort_null_first: List[bool],
     ) -> dd.DataFrame:
         # Split the first column. We need to handle this one with set_index
         first_sort_column = sort_columns[0]
         first_sort_ascending = sort_ascending[0]
+        first_null_first = sort_null_first[0]
 
-        # We can only sort if there are no NaNs or infs.
-        # Therefore we need to do a single pass over the dataframe
-        # to warn the user
-        # We shall also treat inf as na
-        col = df[first_sort_column]
-        isnan = col.isna().any()
-        numeric = pd.api.types.is_numeric_dtype(col.dtype)
-        # Important to evaluate the isinf late, as it only works with numeric-type columns
-        if isnan.compute() or (numeric and da.isinf(col).any().compute()):
-            raise ValueError("Can not sort a column with NaNs")
-
-        df = df.set_index(first_sort_column, drop=False).reset_index(drop=True)
-        if not first_sort_ascending:
-            # As set_index().reset_index() always sorts ascending, we need to reverse
-            # the order inside all partitions and the order of the partitions itself
-            df = df.map_partitions(lambda partition: partition[::-1], meta=df)
-            df = df.partitions[::-1]
+        # Only sort by first column first
+        df = self._sort_first_column(
+            df, first_sort_column, first_sort_ascending, first_null_first
+        )
 
         # sort the remaining columns if given
         if len(sort_columns) > 1:
-            sort_partition_func = lambda x: x.reset_index(drop=True).sort_values(
-                sort_columns, ascending=sort_ascending
+            df = self._sort_secondary_columns(
+                df, sort_columns, sort_ascending, sort_null_first
             )
-            df = df.map_partitions(sort_partition_func, meta=df._meta)
+
+        return df.persist()
+
+    def _sort_secondary_columns(
+        self, df, sort_columns, sort_ascending, sort_null_first
+    ):
+        def sort_partition_func(partition):
+            # We are going to add additional columns here
+            # That is not something we would like to do on the
+            # original data. I hope that this does not have
+            # a huge performance impact
+            partition = partition.copy()
+
+            # pandas does not allow to sort by NaN first/last
+            # differently for different columns. Therefore
+            # we split again by NaN
+            original_columns = partition.columns
+            tmp_columns = []
+            tmp_ascending = []
+
+            for col, asc, null_first in zip(
+                sort_columns, sort_ascending, sort_null_first
+            ):
+                is_null_col = new_temporary_column(partition)
+                partition[is_null_col] = partition[col].isna()
+                tmp_columns += [is_null_col]
+
+                if null_first:
+                    tmp_ascending += [False]
+                else:
+                    tmp_ascending += [True]
+
+                filled_nan_col = new_temporary_column(partition)
+                # the actual value does not matter
+                partition[filled_nan_col] = partition[col].fillna(0)
+                tmp_columns += [filled_nan_col]
+                tmp_ascending += [asc]
+
+            partition = partition.sort_values(tmp_columns, ascending=tmp_ascending)
+            return partition[original_columns]
+
+        return df.map_partitions(sort_partition_func, meta=df._meta)
+
+    def _sort_first_column(
+        self, df, first_sort_column, first_sort_ascending, first_null_first
+    ):
+        # Dask can only sort if there are no NaNs in the first column.
+        # Therefore we need to do a single pass over the dataframe
+        # to check if we have NaNs in the first column
+        # If this is the case, we concat the NaN values to the front
+        # That might be a very complex operation and should
+        # in general be avoided
+        col = df[first_sort_column]
+        is_na = col.isna().persist()
+        if is_na.any().compute():
+            df_is_na = df[is_na].reset_index(drop=True)
+            df_not_is_na = (
+                df[~is_na]
+                .set_index(first_sort_column, drop=False)
+                .reset_index(drop=True)
+            )
+        else:
+            df_is_na = None
+            df_not_is_na = df.set_index(first_sort_column, drop=False).reset_index(
+                drop=True
+            )
+        if not first_sort_ascending:
+            # As set_index().reset_index() always sorts ascending, we need to reverse
+            # the order inside all partitions and the order of the partitions itself
+            # We do not need to do this for the nan-partitions
+            df_not_is_na = df_not_is_na.map_partitions(
+                lambda partition: partition[::-1], meta=df
+            )
+            df_not_is_na = df_not_is_na.partitions[::-1]
+
+        if df_is_na is not None:
+            if first_null_first:
+                df = dd.concat([df_is_na, df_not_is_na])
+            else:
+                df = dd.concat([df_not_is_na, df_is_na])
+        else:
+            df = df_not_is_na
 
         return df
 
@@ -104,7 +181,7 @@ class LogicalSortPlugin(BaseRelPlugin):
         """
         if not offset:
             # We do a (hopefully) very quick check: if the first partition
-            # is already enough, we will just ust this
+            # is already enough, we will just use this
             first_partition_length = len(df.partitions[0])
             if first_partition_length >= end:
                 return df.head(end, compute=False)

--- a/tests/integration/test_postgres.py
+++ b/tests/integration/test_postgres.py
@@ -127,23 +127,21 @@ def test_join(assert_query_gives_same_result):
 
 
 def test_sort(assert_query_gives_same_result):
-    # TODO: this test fails, as NaNs are sorted differently
-    # in pandas and postgresql
-    # assert_query_gives_same_result(
-    #     """
-    #     SELECT
-    #         user_id, b
-    #     FROM df1
-    #     ORDER BY b, user_id DESC
-    # """
-    # )
+    assert_query_gives_same_result(
+        """
+        SELECT
+            user_id, b
+        FROM df1
+        ORDER BY b NULLS FIRST, user_id DESC NULLS FIRST
+    """
+    )
 
     assert_query_gives_same_result(
         """
         SELECT
             c, d
         FROM df2
-        ORDER BY c, d, user_id
+        ORDER BY c NULLS FIRST, d NULLS FIRST, user_id NULLS FIRST
     """
     )
 
@@ -154,7 +152,7 @@ def test_limit(assert_query_gives_same_result):
         SELECT
             c, d
         FROM df2
-        ORDER BY c, d, user_id
+        ORDER BY c NULLS FIRST, d NULLS FIRST, user_id NULLS FIRST
         LIMIT 10 OFFSET 20
     """
     )
@@ -164,7 +162,7 @@ def test_limit(assert_query_gives_same_result):
         SELECT
             c, d
         FROM df2
-        ORDER BY c, d, user_id
+        ORDER BY c NULLS FIRST, d NULLS FIRST, user_id NULLS FIRST
         LIMIT 200
     """
     )

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -58,7 +58,7 @@ def test_sort(assert_query_gives_same_result):
         SELECT
             user_id, b
         FROM df1
-        ORDER BY b, user_id DESC
+        ORDER BY b NULLS FIRST, user_id DESC NULLS FIRST
     """
     )
 


### PR DESCRIPTION
So far, dask-sql does not support sorting columns with NaNs, as the `set_index` trick does not work (as divisions can not be calculated on NaNs). 
This PR fixes this. We have two different techniques here, depending if we only have one column to sort or multiples:
* for the first sort column, we split out all None values and all non-None values, sort only the latter part and then concat again. This has also the nice property of putting all None-rows into a different partition
* for the second (and more) sort column, we only need to sort things intra-partition (as the first sorting implies, that rows with the same value in the first sort column end up in the same partition). We therefore use `map_partition` and pandas functionality. We use a technique similar to what other packages, e.g. fugue are doing and add temporary columns (one for is None/is not None and one with all None values set to 0). We can then sort according to them.

This PR also adds support for `NULLS FIRST` or `NULLS LAST`.