### PR TITLE
Pip installation docs improvement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,13 +19,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v1-${{ hashFiles('conda.yaml') }}
+          key: ${{ runner.os }}-conda-v1-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install --file conda.yaml -c conda-forge
+          conda install --file conda.txt -c conda-forge
           pip install setuptools wheel twine
           which python
           pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v1-${{ hashFiles('conda.yaml') }}
+          key: ${{ runner.os }}-conda-v1-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
       - name: Install dependencies and build the jar
         shell: bash -l {0}
         run: |
-          conda install --file conda.yaml -c conda-forge
+          conda install --file conda.txt -c conda-forge
           which python
           pip list
           conda list
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v1-${{ matrix.java }}-${{ hashFiles('conda.yaml') }}
+          key: ${{ runner.os }}-conda-v1-${{ matrix.java }}-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
       - name: Download the pre-build jar
@@ -78,7 +78,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install python=${{ matrix.python }} --file conda.yaml -c conda-forge
+          conda install python=${{ matrix.python }} --file conda.txt -c conda-forge
       - name: Install sqlalchemy and docker pkg for postgres test
         shell: bash -l {0}
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM daskdev/dask:2.30.0
 LABEL author "Nils Braun <nilslennartbraun@gmail.com>"
 
 # Install dependencies for dask-sql
-COPY conda.yaml /opt/dask_sql/
+COPY conda.txt /opt/dask_sql/
 RUN conda config --add channels conda-forge \
  && /opt/conda/bin/conda install --freeze-installed \
         "jpype1>=1.0.2" \

--- a/README.md
+++ b/README.md
@@ -129,7 +129,11 @@ If you want to have the newest (unreleased) `dask-sql` version or if you plan to
 
 Create a new conda environment and install the development environment:
 
-    conda create -n dask-sql --file conda.yaml -c conda-forge
+    conda create -n dask-sql --file conda.txt -c conda-forge
+
+It is not recommended to use `pip` instead of `conda`.
+If you however need to, make sure to have Java (jdk >= 8) and maven installed and correctly setup before continuing.
+Have a look into `conda.txt` for the rest of the development environment.
 
 After that, you can install the package in development mode
 

--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ Have a look into `conda.txt` for the rest of the development environment.
 
 After that, you can install the package in development mode
 
-    pip install -e .
+    pip install -e ".[dev]"
 
-This will also compile the Java classes. If there were changes to the Java code, you need to rerun this compilation with
+To compile the Java classes (at the beginning or after changes), run
 
     python setup.py java
 

--- a/conda.txt
+++ b/conda.txt
@@ -4,7 +4,7 @@ pandas<1.2.0 # pandas 1.2.0 introduced float NaN dtype,
              # which is currently not working with postgres,
              # so the test is failing
 jpype1>=1.0.2
-openjdk>=11
+openjdk>=8
 maven>=3.6.0
 pytest>=6.0.1
 pytest-cov>=2.10.1

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -57,7 +57,11 @@ Create a new conda environment and install the development environment:
 
 .. code-block:: bash
 
-    conda create -n dask-sql --file conda.yaml -c conda-forge
+    conda create -n dask-sql --file conda.txt -c conda-forge
+
+It is not recommended to use ``pip`` instead of ``conda``.
+If you however need to, make sure to have Java (jdk >= 8) and maven installed and correctly setup before continuing.
+Have a look into ``conda.txt`` for the rest of the development environment.
 
 After that, you can install the package in development mode
 

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -67,10 +67,9 @@ After that, you can install the package in development mode
 
 .. code-block:: bash
 
-    pip install -e .
+    pip install -e ".[dev]"
 
-This will also compile the Java classes.
-If there were changes to the Java code, you need to rerun this compilation with
+To compile the Java classes (at the beginning or after changes), run
 
 .. code-block:: bash
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,12 @@ class MavenCommand(distutils.cmd.Command):
         """Run the mvn installation command"""
         # We need to explicitely specify the full path to mvn
         # for Windows
-        command = [shutil.which("mvn"), "clean", "install", "-f", "pom.xml"]
+        maven_command = shutil.which("mvn")
+        if not maven_command:
+            raise OSError(
+                "Can not find the mvn (maven) binary. Make sure to install maven before building the jar."
+            )
+        command = [maven_command, "clean", "install", "-f", "pom.xml"]
         self.announce(f"Running command: {' '.join(command)}", level=distutils.log.INFO)
 
         subprocess.check_call(command, cwd="planner")

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,18 @@ setup(
         # backport for python versions without importlib.metadata
         "importlib_metadata; python_version < '3.8.0'",
     ],
+    extras_require={
+        "dev": [
+            "pytest>=6.0.1",
+            "pytest-cov>=2.10.1",
+            "mock>=4.0.3",
+            "sphinx>=3.2.1",
+            "pyarrow>=0.15.1",
+            "dask-ml>=1.7.0",
+            "scikit-learn<0.24.0",
+            "intake>=0.6.0",
+        ]
+    },
     entry_points={
         "console_scripts": [
             "dask-sql-server = dask_sql.server.app:main",


### PR DESCRIPTION
Related to #127 
* Added a better error message on missing maven installation
* Make pip installation more clear in the docs
* Move `conda.yaml` to `conda.txt` (as it is not a yaml)
* Add a dev environment, which an be installed via `.[dev]`