### PR TITLE
Fix integration with dbfs using the newest fsspec version

### DIFF
--- a/docs/pages/data_input.rst
+++ b/docs/pages/data_input.rst
@@ -8,7 +8,7 @@ For this, ``dask-sql`` uses the wide field of possible `input formats  <https://
 You have multiple possibilities to load input data in ``dask-sql``:
 
 1. Load it via python
--------------------------------
+---------------------
 
 You can either use already created dask dataframes or create one by using the :func:`~dask_sql.Context.create_table` function.
 Chances are high, there exists already a function to load your favorite format or location (e.g. s3 or hdfs).
@@ -163,6 +163,26 @@ Input Formats
   Again, ``hive_table_name`` is optional and defaults to the table name in ``dask-sql``.
   You can also control the database used in Hive via the ``hive_schema_name`` parameter.
   Additional arguments are pushed to the internally called ``read_<format>`` functions.
+* Similarly, it is possible to load data from a `Databricks Cluster <https://docs.databricks.com/clusters/index.html>`_ (which is similar to a Hive metastore).
+
+  You need to have the ``databricks-dbapi`` package installed and ``fsspec >= 0.8.7``.
+  The variables ``token``, ``host``, ``port`` and ``http_path`` come from the databricks cluster definition.
+  A token needs to be `generated <https://docs.databricks.com/dev-tools/api/latest/authentication.html>`_ for the accessing user.
+  The remaining information can be found in the JDBC tab of the cluster.
+
+  .. code-block:: python
+
+    from dask_sql import Context
+    from sqlalchemy import create_engine
+
+    c = Context()
+
+    cursor = create_engine(f"databricks+pyhive://token:{token}@{host}:{port}/",
+                           connect_args={"http_path": http_path}).connect()
+
+    c.create_table("my_data", cursor, hive_table_name="schema.table",
+                   storage_options={"instance": host, "token": token})
+
 
 .. note::
 


### PR DESCRIPTION
I finally found some time to debug the dbfs (databricks) integration mentioned in #83. After the integration of dbfs into fsspec (which is, so far, not released - so you need the HEAD version to try this) I could follow the descriptions by @raybellwaves in the issue:
* setup a databricks cluster on Azure (the community version does not work)
* then execute the lines under "Steps to reproduce" from [here](https://github.com/nils-braun/dask-sql/issues/83#issuecomment-736968990) (thanks for the nice intro, Ray!)
* With the fix from this PR, I am now able to execute this:
```python
from sqlalchemy import create_engine
from dask_sql import Context

dbfs_engine = create_engine(f"databricks+pyhive://token:{token}@{host}:{port}/", 
                            connect_args={"http_path": http_path}
                           ).connect()

c = Context()
c.create_table("df", cursor, hive_table_name="tmp.df", storage_options={"instance": host, "token": token})
```
and it works :-)