### PR TITLE
Hive/Databricks from SQL

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -107,6 +107,7 @@ class Context:
         InputUtil.add_plugin_class(input_utils.PandasInputPlugin, replace=False)
         InputUtil.add_plugin_class(input_utils.HiveInputPlugin, replace=False)
         InputUtil.add_plugin_class(input_utils.IntakeCatalogInputPlugin, replace=False)
+        InputUtil.add_plugin_class(input_utils.SqlalchemyHiveInputPlugin, replace=False)
         # needs to be the last entry, as it only checks for string
         InputUtil.add_plugin_class(input_utils.LocationInputPlugin, replace=False)
 

--- a/dask_sql/input_utils/__init__.py
+++ b/dask_sql/input_utils/__init__.py
@@ -4,6 +4,7 @@ from .hive import HiveInputPlugin
 from .intake import IntakeCatalogInputPlugin
 from .location import LocationInputPlugin
 from .pandas import PandasInputPlugin
+from .sqlalchemy import SqlalchemyHiveInputPlugin
 
 __all__ = [
     InputUtil,
@@ -13,4 +14,5 @@ __all__ = [
     IntakeCatalogInputPlugin,
     LocationInputPlugin,
     PandasInputPlugin,
+    SqlalchemyHiveInputPlugin,
 ]

--- a/dask_sql/input_utils/sqlalchemy.py
+++ b/dask_sql/input_utils/sqlalchemy.py
@@ -1,0 +1,32 @@
+from typing import Any
+from dask_sql.input_utils.hive import HiveInputPlugin
+
+
+class SqlalchemyHiveInputPlugin(HiveInputPlugin):
+    """Input Plugin from sqlalchemy string"""
+
+    def is_correct_input(
+        self, input_item: Any, table_name: str, format: str = None, **kwargs
+    ):
+        correct_prefix = isinstance(input_item, str) and (
+            input_item.startswith("hive://")
+            or input_item.startswith("databricks+pyhive://")
+        )
+        return correct_prefix
+
+    def to_dc(
+        self, input_item: Any, table_name: str, format: str = None, **kwargs
+    ):  # pragma: no cover
+        import sqlalchemy
+
+        engine_kwargs = {}
+        if "connect_args" in kwargs:
+            engine_kwargs["connect_args"] = kwargs.pop("connect_args")
+
+        if format is not None:
+            raise AttributeError(
+                "Format specified and sqlalchemy connection string set!"
+            )
+
+        cursor = sqlalchemy.create_engine(input_item, **engine_kwargs).connect()
+        return super().to_dc(cursor, table_name=table_name, **kwargs)

--- a/dask_sql/physical/rel/custom/create_table.py
+++ b/dask_sql/physical/rel/custom/create_table.py
@@ -52,7 +52,9 @@ class CreateTablePlugin(BaseRelPlugin):
             f"Creating new table with name {table_name} and parameters {kwargs}"
         )
 
-        format = kwargs.pop("format", "csv").lower()
+        format = kwargs.pop("format", None)
+        if format:  # pragma: no cover
+            format = format.lower()
         persist = kwargs.pop("persist", False)
 
         try:

--- a/docs/pages/data_input.rst
+++ b/docs/pages/data_input.rst
@@ -127,7 +127,7 @@ Input Formats
 
   or via SQL:
 
-  .. code-block:: python
+  .. code-block:: sql
 
     CREATE TABLE my_data WITH (
         format = 'intake',
@@ -144,8 +144,6 @@ Input Formats
 
   It is both possible to use a `pyhive.hive.Cursor` or an `sqlalchemy` connection.
 
-  Currently, this feature is only accessible via the Python API.
-
   .. code-block:: python
 
     from dask_sql import Context
@@ -160,15 +158,23 @@ Input Formats
 
     c.create_table("my_data", cursor, hive_table_name="the_name_in_hive")
 
+  or in SQL:
+
+  .. code-block:: sql
+
+    CREATE TABLE my_data WITH (
+        location = 'hive://hive-server:10000',
+        hive_table_name = 'the_name_in_hive'
+    )
+
   Again, ``hive_table_name`` is optional and defaults to the table name in ``dask-sql``.
   You can also control the database used in Hive via the ``hive_schema_name`` parameter.
   Additional arguments are pushed to the internally called ``read_<format>`` functions.
 * Similarly, it is possible to load data from a `Databricks Cluster <https://docs.databricks.com/clusters/index.html>`_ (which is similar to a Hive metastore).
 
   You need to have the ``databricks-dbapi`` package installed and ``fsspec >= 0.8.7``.
-  The variables ``token``, ``host``, ``port`` and ``http_path`` come from the databricks cluster definition.
   A token needs to be `generated <https://docs.databricks.com/dev-tools/api/latest/authentication.html>`_ for the accessing user.
-  The remaining information can be found in the JDBC tab of the cluster.
+  The ``host``, ``port`` and ``http_path`` information can be found in the JDBC tab of the cluster.
 
   .. code-block:: python
 
@@ -183,6 +189,21 @@ Input Formats
     c.create_table("my_data", cursor, hive_table_name="schema.table",
                    storage_options={"instance": host, "token": token})
 
+  or in SQL
+
+  .. code-block:: sql
+
+    CREATE TABLE my_data WITH (
+        location = 'databricks+pyhive://token:{token}@{host}:{port}/',
+        connect_args = (
+            http_path = '{http_path}'
+        ),
+        hive_table_name = 'schema.table',
+        storage_options = (
+            instance = '{host}',
+            token = '{token}'
+        )
+    )
 
 .. note::
 


### PR DESCRIPTION
Allows to create tables from databricks/hive directly
from SQL "CREATE TABLE" calls by creating
a sqlalchemy cursor on the fly.

Fixes #144 