### PR TITLE
Limit the dask version until the dask-ml problem is fixed

### DIFF
--- a/conda.txt
+++ b/conda.txt
@@ -1,5 +1,8 @@
 python>=3.7
-dask>=2.19.0
+dask>=2.19.0,<=2021.2.0  # dask 2021.3.0 makes
+                         # dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+                         # and introduces a different quantile method (which so far
+                         # gives unreasonable results)
 pandas<1.2.0,>=1.0.0  # pandas 1.2.0 introduced float NaN dtype,
                       # which is currently not working with dask,
                       # so the test is failing, see https://github.com/dask/dask/issues/7156

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,10 @@ setup(
     python_requires=">=3.6",
     setup_requires=["setuptools_scm"] + sphinx_requirements,
     install_requires=[
-        "dask[dataframe]>=2.19.0",
+        "dask[dataframe]>=2.19.0,<=2021.2.0",  # dask 2021.3.0 makes
+        # dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+        # and introduces a different quantile method (which so far
+        # gives unreasonable results)
         "pandas<1.2.0,>=1.0.0",  # pandas 1.2.0 introduced float NaN dtype,
         # which is currently not working with dask,
         # so the test is failing, see https://github.com/dask/dask/issues/7156


### PR DESCRIPTION
Until https://github.com/dask/dask-ml/issues/803 is fixed, we better limit the Dask version.