### PR TITLE
Better cross joins

### DIFF
--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -5,7 +5,9 @@ from functools import reduce
 from typing import List, Tuple
 
 import dask.dataframe as dd
-import numpy as np
+import pandas as pd
+from dask.base import tokenize
+from dask.highlevelgraph import HighLevelGraph
 
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.java import org
@@ -92,53 +94,60 @@ class LogicalJoinPlugin(BaseRelPlugin):
         # We therefore create new columns on purpose, which have a distinct name.
         assert len(lhs_on) == len(rhs_on)
         if lhs_on:
-            lhs_columns_to_add = {
-                f"common_{i}": df_lhs_renamed.iloc[:, index]
-                for i, index in enumerate(lhs_on)
-            }
-            rhs_columns_to_add = {
-                f"common_{i}": df_rhs_renamed.iloc[:, index]
-                for i, index in enumerate(rhs_on)
-            }
-
-            # SQL compatibility: when joining on columns that
-            # contain NULLs, pandas will actually happily
-            # keep those NULLs. That is however not compatible with
-            # SQL, so we get rid of them here
-            if join_type in ["inner", "right"]:
-                df_lhs_filter = reduce(
-                    operator.and_,
-                    [~df_lhs_renamed.iloc[:, index].isna() for index in lhs_on],
-                )
-                df_lhs_renamed = df_lhs_renamed[df_lhs_filter]
-            if join_type in ["inner", "left"]:
-                df_rhs_filter = reduce(
-                    operator.and_,
-                    [~df_rhs_renamed.iloc[:, index].isna() for index in rhs_on],
-                )
-                df_rhs_renamed = df_rhs_renamed[df_rhs_filter]
+            # 5. Now we can finally merge on these columns
+            # The resulting dataframe will contain all (renamed) columns from the lhs and rhs
+            # plus the added columns
+            df = self._join_on_columns(
+                df_lhs_renamed, df_rhs_renamed, lhs_on, rhs_on, join_type,
+            )
         else:
-            # We are in the complex join case
+            # 5. We are in the complex join case
             # where we have no column to merge on
             # This means we have no other chance than to merge
             # everything with everything...
-            # We add a 1-column to merge on
-            lhs_columns_to_add = {"common": 1}
-            rhs_columns_to_add = {"common": 1}
+
+            # TODO: we should implement a shortcut
+            # for filter conditions that are always false
+
+            def merge_single_partitions(lhs_partition, rhs_partition):
+                # Do a cross join with the two partitions
+                # TODO: it would be nice to apply the filter already here
+                # problem: this would mean we need to ship the rex to the
+                # workers (as this is executed on the workers),
+                # which is definitely not possible (java dependency, JVM start...)
+                lhs_partition = lhs_partition.assign(common=1)
+                rhs_partition = rhs_partition.assign(common=1)
+                merged_data = pd.merge(lhs_partition, rhs_partition, on=["common"])
+
+                return merged_data
+
+            # Iterate nested over all partitions from lhs and rhs and merge them
+            name = "cross-join-" + tokenize(df_lhs_renamed, df_rhs_renamed)
+            dsk = {
+                (name, i * df_rhs_renamed.npartitions + j): (
+                    merge_single_partitions,
+                    (df_lhs_renamed._name, i),
+                    (df_rhs_renamed._name, j),
+                )
+                for i in range(df_lhs_renamed.npartitions)
+                for j in range(df_rhs_renamed.npartitions)
+            }
+
+            graph = HighLevelGraph.from_collections(
+                name, dsk, dependencies=[df_lhs_renamed, df_rhs_renamed]
+            )
+
+            meta = pd.concat(
+                [df_lhs_renamed._meta_nonempty, df_rhs_renamed._meta_nonempty], axis=1
+            )
+            # TODO: Do we know the divisions in any way here?
+            divisions = [None] * (len(dsk) + 1)
+            df = dd.DataFrame(graph, name, meta=meta, divisions=divisions)
 
             warnings.warn(
                 "Need to do a cross-join, which is typically very resource heavy",
                 ResourceWarning,
             )
-
-        df_lhs_with_tmp = df_lhs_renamed.assign(**lhs_columns_to_add)
-        df_rhs_with_tmp = df_rhs_renamed.assign(**rhs_columns_to_add)
-        added_columns = list(lhs_columns_to_add.keys())
-
-        # 5. Now we can finally merge on these columns
-        # The resulting dataframe will contain all (renamed) columns from the lhs and rhs
-        # plus the added columns
-        df = dd.merge(df_lhs_with_tmp, df_rhs_with_tmp, on=added_columns, how=join_type)
 
         # 6. So the next step is to make sure
         # we have the correct column order (and to remove the temporary join columns)
@@ -156,7 +165,7 @@ class LogicalJoinPlugin(BaseRelPlugin):
                 for from_col, to_col in zip(cc.columns, field_specifications)
             }
         )
-        cc = self.fix_column_to_row_type(cc, rel.getRowType())
+        cc = self.fix_column_to_row_type(cc, row_type)
         dc = DataContainer(df, cc)
 
         # 7. Last but not least we apply any filters by and-chaining together the filters
@@ -175,6 +184,48 @@ class LogicalJoinPlugin(BaseRelPlugin):
 
         dc = self.fix_dtype_to_row_type(dc, rel.getRowType())
         return dc
+
+    def _join_on_columns(
+        self,
+        df_lhs_renamed: dd.DataFrame,
+        df_rhs_renamed: dd.DataFrame,
+        lhs_on: List[str],
+        rhs_on: List[str],
+        join_type: str,
+    ) -> dd.DataFrame:
+        lhs_columns_to_add = {
+            f"common_{i}": df_lhs_renamed.iloc[:, index]
+            for i, index in enumerate(lhs_on)
+        }
+        rhs_columns_to_add = {
+            f"common_{i}": df_rhs_renamed.iloc[:, index]
+            for i, index in enumerate(rhs_on)
+        }
+
+        # SQL compatibility: when joining on columns that
+        # contain NULLs, pandas will actually happily
+        # keep those NULLs. That is however not compatible with
+        # SQL, so we get rid of them here
+        if join_type in ["inner", "right"]:
+            df_lhs_filter = reduce(
+                operator.and_,
+                [~df_lhs_renamed.iloc[:, index].isna() for index in lhs_on],
+            )
+            df_lhs_renamed = df_lhs_renamed[df_lhs_filter]
+        if join_type in ["inner", "left"]:
+            df_rhs_filter = reduce(
+                operator.and_,
+                [~df_rhs_renamed.iloc[:, index].isna() for index in rhs_on],
+            )
+            df_rhs_renamed = df_rhs_renamed[df_rhs_filter]
+
+        df_lhs_with_tmp = df_lhs_renamed.assign(**lhs_columns_to_add)
+        df_rhs_with_tmp = df_rhs_renamed.assign(**rhs_columns_to_add)
+        added_columns = list(lhs_columns_to_add.keys())
+
+        df = dd.merge(df_lhs_with_tmp, df_rhs_with_tmp, on=added_columns, how=join_type)
+
+        return df
 
     def _split_join_condition(
         self, join_condition: "org.apache.calcite.rex.RexCall"
@@ -242,6 +293,6 @@ class LogicalJoinPlugin(BaseRelPlugin):
 
             return lhs_index, rhs_index
 
-        raise TypeError(
+        raise AssertionError(
             "Invalid join condition"
         )  # pragma: no cover. Do not how how it could be triggered.

--- a/tests/integration/test_join.py
+++ b/tests/integration/test_join.py
@@ -183,4 +183,4 @@ def test_join_literal(c):
 
     df_expected = pd.DataFrame({"user_id": [], "b": [], "user_id0": [], "c": []})
 
-    assert_frame_equal(df, df_expected, check_dtype=False)
+    assert_frame_equal(df.reset_index(), df_expected.reset_index(), check_dtype=False)


### PR DESCRIPTION
This PR implements a new way to perform "complex" joins where the joining condition is not in the form `a = b` or `a = b AND c = d AND ...` but can have any form.
In general, there is no other way than to perform a full cross join and test the condition on each resulting row. Before this PR, this was done by copying all data to the same machine (bad!) - this PR introduces a distributed cross join by joining every partition with every other partition. After that, the join condition is applied as a filter.

Maybe this solves the issue #148 
This still has the big problem of first producing many output rows and then (hopefully) filtering down, but I do not see any other way to do this.