### PR TITLE
Allow to start a SQL server from a jupyter notebook

### DIFF
--- a/conda.txt
+++ b/conda.txt
@@ -16,6 +16,7 @@ mock>=4.0.3
 sphinx>=3.2.1
 tzlocal>=2.1
 fastapi>=0.61.1
+nest-asyncio>=1.4.3
 uvicorn>=0.11.3
 pyarrow>=0.15.1
 prompt_toolkit>=3.0.8

--- a/docs/pages/server.rst
+++ b/docs/pages/server.rst
@@ -25,6 +25,12 @@ or by running these lines of code
 
     run_server()
 
+or directly with a created context
+
+.. code-block:: python
+
+    c.run_server()
+
 or by using the created docker image
 
 .. code-block:: bash
@@ -123,3 +129,36 @@ To run a standalone SQL server in your ``dask`` cluster, follow these three step
 
 The ``dask-sql`` SQL server was successfully tested with `Apache Hue <https://gethue.com/>`_, `Apache Superset <https://superset.apache.org/>`_
 and `Metabase <https://www.metabase.com/>`_.
+
+
+Running from a jupyter notebook
+-------------------------------
+
+If you quickly want to bridge the gap between your jupyter notebook and a BI tool,
+you can run a temporary SQL server from your jupyter notebook.
+
+.. code-block:: python
+
+    # Create a Context and work with it
+    from dask_sql import Context
+    c = Context()
+
+    ...
+
+    # Later create a temporary server
+    c.run_server(blocking=False)
+
+    # Continue working
+
+This allows you to access the same context with all its registered tables
+both in the jupyter notebook as well as by connecting to the SQL server
+started on port 8080 (e.g. with your BI tool).
+
+Once you are done with the SQL server, you can close it with
+
+.. code-block:: python
+
+    c.stop_server()
+
+Please note that this feature should not be used for productive SQL servers,
+but just for quick analyses via an external application.

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
         "tzlocal>=2.1",
         "prompt_toolkit",
         "pygments",
+        "nest-asyncio",
         # backport for python versions without importlib.metadata
         "importlib_metadata; python_version < '3.8.0'",
     ],


### PR DESCRIPTION
This allows to call
```python
c.run_server(blocking=False)
```
from within a jupyter notebook 