### PR TITLE
Add independent dask cluster

### DIFF
--- a/.github/docker-compose.yaml
+++ b/.github/docker-compose.yaml
@@ -8,10 +8,10 @@ services:
         ports:
             - "8786:8786"
         environment:
-            EXTRA_CONDA_PACKAGES: "pandas>=1.2"
+            EXTRA_CONDA_PACKAGES: "pandas>=1.2 numpy=1.20.2 -c conda-forge"
     dask-worker:
         container_name: dask-worker
         image: daskdev/dask:latest
         command: dask-worker dask-scheduler:8786
         environment:
-            EXTRA_CONDA_PACKAGES: "pandas>=1.2"
+            EXTRA_CONDA_PACKAGES: "pandas>=1.2 numpy=1.20.2 -c conda-forge"

--- a/.github/docker-compose.yaml
+++ b/.github/docker-compose.yaml
@@ -3,15 +3,15 @@ version: '3'
 services:
     dask-scheduler:
         container_name: dask-scheduler
-        image: daskdev/dask:2021.2.0
+        image: daskdev/dask:latest
         command: dask-scheduler
         ports:
             - "8786:8786"
         environment:
-            EXTRA_CONDA_PACKAGES: "pandas=1.1.5"
+            EXTRA_CONDA_PACKAGES: "pandas>=1.2"
     dask-worker:
         container_name: dask-worker
-        image: daskdev/dask:2021.2.0
+        image: daskdev/dask:latest
         command: dask-worker dask-scheduler:8786
         environment:
-            EXTRA_CONDA_PACKAGES: "pandas=1.1.5"
+            EXTRA_CONDA_PACKAGES: "pandas>=1.2"

--- a/.github/docker-compose.yaml
+++ b/.github/docker-compose.yaml
@@ -1,0 +1,17 @@
+# Docker-compose setup used during tests
+version: '3'
+services:
+    dask-scheduler:
+        container_name: dask-scheduler
+        image: daskdev/dask:2021.2.0
+        command: dask-scheduler
+        ports:
+            - "8786:8786"
+        environment:
+            EXTRA_CONDA_PACKAGES: "pandas=1.1.5"
+    dask-worker:
+        container_name: dask-worker
+        image: daskdev/dask:2021.2.0
+        command: dask-worker dask-scheduler:8786
+        environment:
+            EXTRA_CONDA_PACKAGES: "pandas=1.1.5"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v2-${{ matrix.java }}-${{ hashFiles('conda.txt') }}
+          key: ${{ runner.os }}-conda-v2-${{ matrix.java }}-${{ matrix.python }}-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -137,6 +137,12 @@ jobs:
           key: ${{ runner.os }}-conda-v2-11-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.8
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
+          use-only-tar-bz2: true
       - name: Download the pre-build jar
         uses: actions/download-artifact@v1
         with:
@@ -145,11 +151,11 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install python-blosc lz4 --file conda.txt -c conda-forge
+          mamba install python=3.8 python-blosc lz4 --file conda.txt -c conda-forge
 
           which python
           pip list
-          conda list
+          mamba list
       - name: run a dask cluster
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,5 +152,8 @@ jobs:
           docker logs dask-worker
 
           pytest tests/integration/test_compatibility.py
+
+          docker kill dask-scheduler
+          docker kill dask-worker
         env:
           DASK_SQL_TEST_SCHEDULER: tcp://127.0.0.1:8786

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,17 +133,23 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install python=3.7 sqlalchemy psycopg2 --file conda.txt -c conda-forge
+          conda install python=3.7 python-blosc lz4 --file conda.txt -c conda-forge
           pip install docker "fugue[sql]>=0.5.3"
 
           which python
           pip list
           conda list
-      - name: Install Java (again) and test with pytest
+      - name: Test with pytest while running an independent dask cluster
         shell: bash -l {0}
         run: |
-          docker run --rm -it -e EXTRA_CONDA_PACKAGES="pandas=1.2.4" --name dask-scheduler -d --network=host daskdev/dask:2021.4.1 dask-scheduler
-          docker run --rm -it -e EXTRA_CONDA_PACKAGES="pandas=1.2.4" --name dask-worker -d --network=host daskdev/dask:2021.4.1 dask-worker 127.0.0.1:8786
+          docker run --rm -it -e EXTRA_CONDA_PACKAGES="pandas=1.1.5" --name dask-scheduler -d --network=host daskdev/dask:2021.2.0 dask-scheduler
+          docker run --rm -it -e EXTRA_CONDA_PACKAGES="pandas=1.1.5" --name dask-worker -d --network=host daskdev/dask:2021.2.0 dask-worker 127.0.0.1:8786
+
+          # Wait for installation
+          sleep 20
+
+          docker logs dask-scheduler
+          docker logs dask-worker
 
           pytest tests/integration/test_compatibility.py
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,3 +107,44 @@ jobs:
         if: ${{ always() }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
+  test_independent:
+    name: "Test in a dask cluster"
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-v1-11-${{ hashFiles('**/pom.xml') }}
+      - name: Cache downloaded conda packages
+        uses: actions/cache@v2
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-v1-11-${{ hashFiles('conda.txt') }}
+      - name: Set up Python
+        uses: conda-incubator/setup-miniconda@v2
+      - name: Download the pre-build jar
+        uses: actions/download-artifact@v1
+        with:
+          name: jar
+          path: dask_sql/jar/
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          conda install python=3.7 sqlalchemy psycopg2 --file conda.txt -c conda-forge
+          pip install docker "fugue[sql]>=0.5.3"
+
+          which python
+          pip list
+          conda list
+      - name: Install Java (again) and test with pytest
+        shell: bash -l {0}
+        run: |
+          docker run --rm -it -e EXTRA_CONDA_PACKAGES="pandas=1.2.4" --name dask-scheduler -d --network=host daskdev/dask:2021.4.1 dask-scheduler
+          docker run --rm -it -e EXTRA_CONDA_PACKAGES="pandas=1.2.4" --name dask-worker -d --network=host daskdev/dask:2021.4.1 dask-worker 127.0.0.1:8786
+
+          pytest tests/integration/test_compatibility.py
+        env:
+          DASK_SQL_TEST_SCHEDULER: tcp://127.0.0.1:8786

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,17 +133,18 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install python=3.7 python-blosc lz4 --file conda.txt -c conda-forge
+          conda install python-blosc lz4 --file conda.txt -c conda-forge
 
           which python
           pip list
           conda list
       - name: run a dask cluster
+        shell: bash -l {0}
         run: |
           docker-compose -f .github/docker-compose.yaml up -d
 
           # Wait for installation
-          sleep 20
+          sleep 40
 
           docker logs dask-scheduler
           docker logs dask-worker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,21 +138,18 @@ jobs:
           which python
           pip list
           conda list
-      - name: Test with pytest while running an independent dask cluster
-        shell: bash -l {0}
+      - name: run a dask cluster
         run: |
-          docker run --rm -it -e EXTRA_CONDA_PACKAGES="pandas=1.1.5" --name dask-scheduler -d --network=host daskdev/dask:2021.2.0 dask-scheduler
-          docker run --rm -it -e EXTRA_CONDA_PACKAGES="pandas=1.1.5" --name dask-worker -d --network=host daskdev/dask:2021.2.0 dask-worker 127.0.0.1:8786
+          docker-compose -f .github/docker-compose.yaml up -d
 
           # Wait for installation
           sleep 20
 
           docker logs dask-scheduler
           docker logs dask-worker
-
-          pytest tests/integration/test_compatibility.py
-
-          docker kill dask-scheduler
-          docker kill dask-worker
-        # env:
-        #   DASK_SQL_TEST_SCHEDULER: tcp://127.0.0.1:8786
+      - name: Test with pytest while running an independent dask cluster
+        shell: bash -l {0}
+        run: |
+          pytest tests
+        env:
+          DASK_SQL_TEST_SCHEDULER: tcp://127.0.0.1:8786

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v1-${{ hashFiles('conda.txt') }}
+          key: ${{ runner.os }}-conda-v2-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
       - name: Install dependencies and build the jar
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v1-${{ matrix.java }}-${{ hashFiles('conda.txt') }}
+          key: ${{ runner.os }}-conda-v2-${{ matrix.java }}-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
       - name: Download the pre-build jar
@@ -122,7 +122,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v1-11-${{ hashFiles('conda.txt') }}
+          key: ${{ runner.os }}-conda-v2-11-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
       - name: Download the pre-build jar
@@ -134,7 +134,6 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install python=3.7 python-blosc lz4 --file conda.txt -c conda-forge
-          pip install docker "fugue[sql]>=0.5.3"
 
           which python
           pip list
@@ -155,5 +154,5 @@ jobs:
 
           docker kill dask-scheduler
           docker kill dask-worker
-        env:
-          DASK_SQL_TEST_SCHEDULER: tcp://127.0.0.1:8786
+        # env:
+        #   DASK_SQL_TEST_SCHEDULER: tcp://127.0.0.1:8786

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -17,7 +17,13 @@ from dask_sql.datacontainer import DataContainer
 from dask_sql.mappings import sql_to_python_type
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rex.base import BaseRexPlugin
-from dask_sql.utils import LoggableDataFrame, convert_to_datetime, is_datetime, is_frame
+from dask_sql.utils import (
+    LoggableDataFrame,
+    convert_to_datetime,
+    is_datetime,
+    is_frame,
+    make_pickable_without_dask_sql,
+)
 
 logger = logging.getLogger(__name__)
 SeriesOrScalar = Union[dd.Series, Any]
@@ -557,7 +563,7 @@ class BaseRandomOperation(Operation):
         state_data = random_state_data(df.npartitions, random_state)
         dsk = {
             (name, i): (
-                self.random_function,
+                make_pickable_without_dask_sql(self.random_function),
                 (df._name, i),
                 np.random.RandomState(state),
                 kwargs,

--- a/dask_sql/physical/rex/core/over.py
+++ b/dask_sql/physical/rex/core/over.py
@@ -266,6 +266,8 @@ class RexOverPlugin(BaseRexPlugin):
         # which is evaluated on the workers
         temporary_operand_columns = temporary_operand_columns.keys()
 
+        new_column_name = new_temporary_column(df)
+
         @make_pickable_without_dask_sql
         def map_on_each_group(partitioned_group):
             if sort_columns:
@@ -279,8 +281,6 @@ class RexOverPlugin(BaseRexPlugin):
             )
 
             return partitioned_group
-
-        new_column_name = new_temporary_column(df)
 
         meta = df._meta_nonempty.assign(**{new_column_name: 0.0})
         df = df.groupby(group_columns).apply(map_on_each_group, meta=meta)

--- a/dask_sql/physical/rex/core/over.py
+++ b/dask_sql/physical/rex/core/over.py
@@ -11,7 +11,11 @@ from dask_sql.physical.rex.convert import RexConverter
 from dask_sql.physical.utils.groupby import get_groupby_with_nulls_cols
 from dask_sql.physical.utils.map import map_on_partition_index
 from dask_sql.physical.utils.sort import sort_partition_func
-from dask_sql.utils import LoggableDataFrame, new_temporary_column
+from dask_sql.utils import (
+    LoggableDataFrame,
+    make_pickable_without_dask_sql,
+    new_temporary_column,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -262,6 +266,7 @@ class RexOverPlugin(BaseRexPlugin):
         # which is evaluated on the workers
         temporary_operand_columns = temporary_operand_columns.keys()
 
+        @make_pickable_without_dask_sql
         def map_on_each_group(partitioned_group):
             if sort_columns:
                 partitioned_group = sort_partition_func(

--- a/dask_sql/physical/utils/sort.py
+++ b/dask_sql/physical/utils/sort.py
@@ -2,7 +2,7 @@ from typing import List
 
 import dask.dataframe as dd
 
-from dask_sql.utils import new_temporary_column
+from dask_sql.utils import make_pickable_without_dask_sql, new_temporary_column
 
 
 def apply_sort(
@@ -24,7 +24,7 @@ def apply_sort(
     # sort the remaining columns if given
     if len(sort_columns) > 1:
         df = df.map_partitions(
-            sort_partition_func,
+            make_pickable_without_dask_sql(sort_partition_func),
             meta=df._meta,
             sort_columns=sort_columns,
             sort_ascending=sort_ascending,

--- a/dask_sql/utils.py
+++ b/dask_sql/utils.py
@@ -1,11 +1,15 @@
 import importlib
 import logging
 import re
+import sys
 from collections import defaultdict
+from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, Callable, Dict, List
+from typing import Any, Dict, List
+from unittest.mock import patch
 from uuid import uuid4
 
+import cloudpickle
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
@@ -273,3 +277,49 @@ def new_temporary_column(df: dd.DataFrame) -> str:
             return col_name
         else:  # pragma: no cover
             continue
+
+
+def make_pickable_without_dask_sql(f):
+    """
+    Helper function turning f into another function which can be deserialized without dask_sql
+
+    When transporting functions from the client to the dask-workers,
+    the are normally pickled. During this process, everything which is "importable"
+    (e.g. references to library function calls or classes) are just replaced by references,
+    to keep the pickled object small. However, in the case of dask-sql we do not assume
+    that the workers also have dask-sql installed, so any usage to dask-sql
+    can not be replaced by a pure reference, but by the actual content of the function/class
+    etc. To reuse as much as possible from the cloudpickle module, we do a very nasty
+    trick here: we replace the logic in the cloudpickle module to find out the origin module
+    to make it look to cloudpickle as if those modules are not importable.
+    """
+
+    class WhichModuleReplacement:
+        """Temporary replacement for the _which_module function"""
+
+        def __init__(self, spec):
+            """Store the original function"""
+            self._old_which_module = spec
+
+        def __call__(self, obj, name):
+            """Ask the original _which_module function for the module and return None, if it is the dask_sql one"""
+            module_name = self._old_which_module(obj, name)
+            module_name_root = module_name.split(".", 1)[0]
+            if module_name_root == "dask_sql":
+                return None
+            return module_name
+
+    with patch(
+        "cloudpickle.cloudpickle._whichmodule",
+        spec=True,
+        new_callable=WhichModuleReplacement,
+    ):
+        pickled_f = cloudpickle.dumps(f)
+
+    def wrapped_f(*args, **kwargs):
+        import cloudpickle
+
+        f = cloudpickle.loads(pickled_f)
+        return f(*args, **kwargs)
+
+    return wrapped_f

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -209,3 +209,9 @@ def setup_dask_client():
     address = os.getenv("DASK_SQL_TEST_SCHEDULER", None)
     if address:
         client = Client(address)
+
+
+skip_if_external_scheduler = pytest.mark.skipif(
+    os.getenv("DASK_SQL_TEST_SCHEDULER", None) is not None,
+    reason="Can not run with external cluster",
+)

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -5,6 +5,7 @@ import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
+from dask.distributed import Client
 from pandas.testing import assert_frame_equal
 
 
@@ -200,3 +201,11 @@ def assert_query_gives_same_result(engine):
         assert_frame_equal(sql_result, dask_result, check_dtype=False, **kwargs)
 
     return _assert_query_gives_same_result
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_dask_client():
+    """Setup a dask client if requested"""
+    address = os.getenv("DASK_SQL_TEST_SCHEDULER", None)
+    if address:
+        client = Client(address)

--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -4,8 +4,10 @@ import pytest
 from pandas.testing import assert_frame_equal
 
 import dask_sql
+from tests.integration.fixtures import skip_if_external_scheduler
 
 
+@skip_if_external_scheduler
 def test_create_from_csv(c, df, temporary_data_file):
     df.to_csv(temporary_data_file, index=False)
 
@@ -52,6 +54,7 @@ def test_cluster_memory(client, c, df):
     assert_frame_equal(df, return_df)
 
 
+@skip_if_external_scheduler
 def test_create_from_csv_persist(c, df, temporary_data_file):
     df.to_csv(temporary_data_file, index=False)
 
@@ -139,6 +142,7 @@ def test_create_from_query(c, df):
     assert_frame_equal(df, return_df)
 
 
+@skip_if_external_scheduler
 def test_view_table_persist(c, temporary_data_file, df):
     df.to_csv(temporary_data_file, index=False)
     c.sql(


### PR DESCRIPTION
One promise of the dask-sql usage is, that you do not need to have dask-sql installed on the cluster to use it.
However, so far there is no test for this implemented, so this promise relies on developers checking it regularly (which might or might not work). Therefore I am proposing a new test on a dedicated docker-based dask cluster along the other tests.