### PR TITLE
Make RexConversion "vertical"

### DIFF
--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -170,21 +170,14 @@ class LogicalJoinPlugin(BaseRelPlugin):
 
         # 7. Last but not least we apply any filters by and-chaining together the filters
         if filter_conditions:
-            filter_columns = []
-
-            for filter_condition in filter_conditions:
-                filter_column, dc = RexConverter.convert(
-                    filter_condition, dc, context=context
-                )
-
-                filter_columns.append(filter_column)
+            filter_columns, dc = RexConverter.convert_and_get_list(
+                filter_conditions, dc, context=context
+            )
 
             # Important: make sure to only dereference the filter columns here
             # as filters might change the order of the dataframe (dis-aligning)
             # previously created columns.
-            filter_condition = reduce(
-                operator.and_, [f.get(dc) for f in filter_columns]
-            )
+            filter_condition = reduce(operator.and_, filter_columns)
             logger.debug(f"Additionally applying filter {filter_condition}")
 
             df = dc.df

--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -80,7 +80,7 @@ class LogicalJoinPlugin(BaseRelPlugin):
         # As this is probably non-sense for large tables, but there is no other
         # known solution so far.
         join_condition = rel.getCondition()
-        lhs_on, rhs_on, filter_condition = self._split_join_condition(join_condition)
+        lhs_on, rhs_on, filter_conditions = self._split_join_condition(join_condition)
 
         logger.debug(f"Joining with type {join_type} on columns {lhs_on}, {rhs_on}.")
 
@@ -169,16 +169,26 @@ class LogicalJoinPlugin(BaseRelPlugin):
         dc = DataContainer(df, cc)
 
         # 7. Last but not least we apply any filters by and-chaining together the filters
-        if filter_condition:
-            # This line is a bit of code duplication with RexCallPlugin - but I guess it is worth to keep it separate
+        if filter_conditions:
+            filter_columns = []
+
+            for filter_condition in filter_conditions:
+                filter_column, dc = RexConverter.convert(
+                    filter_condition, dc, context=context
+                )
+
+                filter_columns.append(filter_column)
+
+            # Important: make sure to only dereference the filter columns here
+            # as filters might change the order of the dataframe (dis-aligning)
+            # previously created columns.
             filter_condition = reduce(
-                operator.and_,
-                [
-                    RexConverter.convert(rex, dc, context=context)
-                    for rex in filter_condition
-                ],
+                operator.and_, [f.get(dc) for f in filter_columns]
             )
             logger.debug(f"Additionally applying filter {filter_condition}")
+
+            df = dc.df
+            cc = dc.column_container
             df = filter_or_scalar(df, filter_condition)
             dc = DataContainer(df, cc)
 
@@ -250,7 +260,7 @@ class LogicalJoinPlugin(BaseRelPlugin):
         if operator_name == "AND":
             lhs_on = []
             rhs_on = []
-            filter_condition = []
+            filter_conditions = []
 
             for operand in operands:
                 try:
@@ -261,10 +271,10 @@ class LogicalJoinPlugin(BaseRelPlugin):
                 except AssertionError:
                     pass
 
-                filter_condition.append(operand)
+                filter_conditions.append(operand)
 
             if lhs_on and rhs_on:
-                return lhs_on, rhs_on, filter_condition
+                return lhs_on, rhs_on, filter_conditions
 
         return [], [], [join_condition]
 

--- a/dask_sql/physical/rel/logical/project.py
+++ b/dask_sql/physical/rel/logical/project.py
@@ -49,28 +49,13 @@ class LogicalProjectPlugin(BaseRelPlugin):
             # Let the rex converter to the real magic
             # we only do some book-keeping here
             logger.debug(f"Adding a new column {key} out of {expr}")
-            new_column, dc = RexConverter.convert(expr, dc, context=context)
+            new_column, dc = RexConverter.convert_to_column_reference(
+                expr, dc, context=context
+            )
 
-            if isinstance(new_column, ScalarValue):
-                # This is a rare case where we actually want to turn a
-                # scalar value into a full column, so we do
-                # this manually here (and not in the corresponding plugin)
-                df = dc.df
-                cc = dc.column_container
-
-                backend_column_name = new_temporary_column(df)
-                df = df.assign(**{backend_column_name: new_column.get()})
-
-                # Make sure to use the newest df in the next iteration
-                dc = DataContainer(df, cc)
-            else:
-                # The column is already stored in the dataframe, so
-                # just store the column name.
-                # Important: do not dereference the column here,
-                # as the dataframe might still change (in future iterations)
-                backend_column_name = new_column._column_name
-
-            mappings[key] = backend_column_name
+            # Important: do not dereference the column here,
+            # as the dataframe might still change (in future iterations)
+            mappings[key] = new_column._column_name
 
         # Make sure the order is correct and name the newly added
         # columns correctly

--- a/dask_sql/physical/rel/logical/values.py
+++ b/dask_sql/physical/rel/logical/values.py
@@ -33,15 +33,17 @@ class LogicalValuesPlugin(BaseRelPlugin):
         for rex_expression_row in rex_expression_rows:
             # We convert each of the cells in the row
             # using a RexConverter.
+            cells = []
+            for rex_cell in rex_expression_row:
+                # We explicitely dismiss the returned DataContainer here
+                # There is no input dc, so why should there by an output dc?
+                cell_value, _ = RexConverter.convert(rex_cell, None, context=context)
+                cells.append(cell_value.get())
+
             # As we do not have any information on the
             # column headers, we just name them with
             # their index.
-            rows.append(
-                {
-                    str(i): RexConverter.convert(rex_cell, None, context=context)
-                    for i, rex_cell in enumerate(rex_expression_row)
-                }
-            )
+            rows.append({str(i): cell_value for i, cell_value in enumerate(cells)})
 
         # TODO: we explicitely reference pandas and dask here -> might we worth making this more general
         # We assume here that when using the values plan, the resulting dataframe will be quite small

--- a/dask_sql/physical/rex/base.py
+++ b/dask_sql/physical/rex/base.py
@@ -6,6 +6,8 @@ import dask_sql
 from dask_sql.datacontainer import DataContainer
 from dask_sql.java import org
 
+SeriesOrScalar = Union[dd.Series, Any]
+
 
 class OutputColumn:
     """Return type of all Rex Plugins. Can store a value or a column reference"""

--- a/dask_sql/physical/rex/base.py
+++ b/dask_sql/physical/rex/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Optional, Tuple, Union
 
 import dask.dataframe as dd
 
@@ -7,13 +7,49 @@ from dask_sql.datacontainer import DataContainer
 from dask_sql.java import org
 
 
+class OutputColumn:
+    """Return type of all Rex Plugins. Can store a value or a column reference"""
+
+    def get(self, dc: DataContainer) -> Union[Any, dd.Series]:
+        """Call this function to turn the reference to a real value (either a scalar or a series)"""
+        raise NotImplementedError
+
+
+class ScalarValue(OutputColumn):
+    """Data class to contain a scalar literal value, used as return of a rex conversion"""
+
+    def __init__(self, value: Any) -> None:
+        self._value: Any = value
+
+    def get(self, dc: Optional[DataContainer] = None) -> Any:
+        return self._value
+
+
+class ColumnReference(OutputColumn):
+    """Data class to contain a column name reference, used as return of a rex conversion"""
+
+    def __init__(self, column_name: str) -> None:
+        self._column_name: str = column_name
+
+    def get(self, dc: DataContainer) -> Any:
+        df = dc.df
+        return df[self._column_name]
+
+
 class BaseRexPlugin:
     """
     Base class for all plugins to convert between
-    a RexNode to a python expression (dask dataframe column or raw value).
+    a RexNode to a python expression
+    (dask dataframe column or raw value).
 
+    The column should be added to the given dataframe and returned as
+    a ColumnReference, whereas the literal value should be returned
+    as a ScalarValue.
     Derived classed needs to override the class_name attribute
     and the convert method.
+
+    Please also have a look into the RexConverter for more
+    documentation on the column outputs.
     """
 
     class_name = None
@@ -23,6 +59,6 @@ class BaseRexPlugin:
         rex: org.apache.calcite.rex.RexNode,
         dc: DataContainer,
         context: "dask_sql.Context",
-    ) -> Union[dd.Series, Any]:
+    ) -> Tuple[OutputColumn, DataContainer]:
         """Base method to implement"""
         raise NotImplementedError

--- a/dask_sql/physical/rex/convert.py
+++ b/dask_sql/physical/rex/convert.py
@@ -1,11 +1,9 @@
 import logging
-from typing import Any, Union
-
-import dask.dataframe as dd
+from typing import Tuple
 
 from dask_sql.datacontainer import DataContainer
 from dask_sql.java import get_java_class
-from dask_sql.physical.rex.base import BaseRexPlugin
+from dask_sql.physical.rex.base import BaseRexPlugin, OutputColumn
 from dask_sql.utils import LoggableDataFrame, Pluggable
 
 logger = logging.getLogger(__name__)
@@ -39,12 +37,47 @@ class RexConverter(Pluggable):
         rex: "org.apache.calcite.rex.RexNode",
         dc: DataContainer,
         context: "dask_sql.Context",
-    ) -> Union[dd.DataFrame, Any]:
+    ) -> Tuple[OutputColumn, DataContainer]:
         """
         Convert the given rel (java instance)
         into a python expression (a dask dataframe)
         using the stored plugins and the dictionary of
         registered dask tables.
+
+        The result of this function consists of
+        the calculation result (in form of a reference to a
+        newly added column or as a scalar value) and
+        the DataContainer. Plugins are allowed to change
+        the datacontainer if needed (e.g. reorder/shuffle the rows).
+
+        Important: do not return columns "as is", but only as references
+        (column names). If you are adding new columns, make sure not
+        to overwrite previous ones.
+
+        Note: A common usage of these plugins, is to use them on
+        a list of input operands. Make sure to resolve the references
+        to the resulting columns only at the end of the list iteration!
+        Intermediate steps might change the datacontainer, so your
+        references might be invalidated.
+        Example, do not do this:
+
+            for o in operands:
+                result, _ = RexConverter.convert(o, dc, ctx)
+                # Reference resolved here, but dc might change
+                # in later iterations!
+                yield result.get(dc)
+
+        but rather this
+
+            results = []
+            for o in operands:
+                result, dc = RexConverter.convert(o, dc, ctx)
+                results.append(result)
+
+            # Reference resolved in the end, after all
+            # operations changing dc are done
+            yield from [r.get(dc) for r in results]
+
         """
         class_name = get_java_class(rex)
 
@@ -59,6 +92,8 @@ class RexConverter(Pluggable):
             f"Processing REX {rex} using {plugin_instance.__class__.__name__}..."
         )
 
-        df = plugin_instance.convert(rex, dc, context=context)
-        logger.debug(f"Processed REX {rex} into {LoggableDataFrame(df)}")
-        return df
+        column, dc = plugin_instance.convert(rex, dc, context=context)
+        logger.debug(
+            f"Processed REX {rex} into {LoggableDataFrame(column)} of {LoggableDataFrame(dc)}"
+        )
+        return column, dc

--- a/dask_sql/physical/rex/core/input_ref.py
+++ b/dask_sql/physical/rex/core/input_ref.py
@@ -1,7 +1,9 @@
+from typing import Tuple
+
 import dask.dataframe as dd
 
 from dask_sql.datacontainer import DataContainer
-from dask_sql.physical.rex.base import BaseRexPlugin
+from dask_sql.physical.rex.base import BaseRexPlugin, ColumnReference, OutputColumn
 
 
 class RexInputRefPlugin(BaseRexPlugin):
@@ -9,6 +11,10 @@ class RexInputRefPlugin(BaseRexPlugin):
     A RexInputRef is an expression, which references a single column.
     It is typically to be found in any expressions which
     calculate a function in a column of a table.
+
+    Important: the returned column reference references
+    the real backend column in the dataframe, not
+    in the frontend.
     """
 
     class_name = "org.apache.calcite.rex.RexInputRef"
@@ -18,11 +24,10 @@ class RexInputRefPlugin(BaseRexPlugin):
         rex: "org.apache.calcite.rex.RexNode",
         dc: DataContainer,
         context: "dask_sql.Context",
-    ) -> dd.Series:
-        df = dc.df
+    ) -> Tuple[OutputColumn, DataContainer]:
         cc = dc.column_container
 
         # The column is references by index
         index = rex.getIndex()
         backend_column_name = cc.get_backend_by_frontend_index(index)
-        return df[backend_column_name]
+        return ColumnReference(backend_column_name), dc

--- a/dask_sql/physical/rex/core/literal.py
+++ b/dask_sql/physical/rex/core/literal.py
@@ -1,11 +1,11 @@
-from typing import Any
+from typing import Any, Tuple
 
 import dask.dataframe as dd
 import numpy as np
 
 from dask_sql.datacontainer import DataContainer
 from dask_sql.mappings import sql_to_python_value
-from dask_sql.physical.rex.base import BaseRexPlugin
+from dask_sql.physical.rex.base import BaseRexPlugin, OutputColumn, ScalarValue
 
 
 class RexLiteralPlugin(BaseRexPlugin):
@@ -25,10 +25,12 @@ class RexLiteralPlugin(BaseRexPlugin):
         rex: "org.apache.calcite.rex.RexNode",
         dc: DataContainer,
         context: "dask_sql.Context",
-    ) -> Any:
+    ) -> Tuple[OutputColumn, DataContainer]:
         literal_value = rex.getValue()
 
         literal_type = str(rex.getType())
         python_value = sql_to_python_value(literal_type, literal_value)
 
-        return python_value
+        # We do not change the dataframe here, as we do not know
+        # if the literal will actually end up in a column or not
+        return ScalarValue(python_value), dc

--- a/dask_sql/physical/rex/core/over.py
+++ b/dask_sql/physical/rex/core/over.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.java import org
-from dask_sql.physical.rex.base import BaseRexPlugin
+from dask_sql.physical.rex.base import BaseRexPlugin, ColumnReference, OutputColumn
 from dask_sql.physical.rex.convert import RexConverter
 from dask_sql.physical.utils.groupby import get_groupby_with_nulls_cols
 from dask_sql.physical.utils.map import map_on_partition_index
@@ -76,10 +76,18 @@ class RexOverPlugin(BaseRexPlugin):
     A RexOver is an expression, which calculates a given function over the dataframe
     while first optionally partitoning the data and optionally sorting it.
 
-    expressions like `F OVER (PARTITION BY x ORDER BY y)` apply f on each
+    Expressions like `F OVER (PARTITION BY x ORDER BY y)` apply f on each
     partition separately and sort by y before applying f. The result of this
     calculation has however the same length as the input dataframe - it is not an aggregation.
     Typical examples include ROW_NUMBER and lagging.
+
+    This is an example for a RexPlugin, which actually changes the incoming
+    dataframe (instead of just returning a single value or adding another column,
+    as most RexPlugins do). It reorders the rows and partitions (shuffles)
+    to make the calculation of the group by much easier.
+
+    Attention: when using an OVER without any partitioning, this will cause all
+    partitions to be merged into a single one!
     """
 
     class_name = "org.apache.calcite.rex.RexOver"
@@ -101,29 +109,19 @@ class RexOverPlugin(BaseRexPlugin):
         rex: "org.apache.calcite.rex.RexNode",
         dc: DataContainer,
         context: "dask_sql.Context",
-    ) -> Any:
+    ) -> Tuple[OutputColumn, DataContainer]:
         window = rex.getWindow()
         self._assert_simple_window(window)
 
-        df = dc.df
-        cc = dc.column_container
-
-        # Store the divisions to apply them later again
-        known_divisions = df.divisions
-
-        # Store the index and sort order to apply them later again
-        df, partition_col, index_col, sort_col = self._preserve_index_and_sort(df)
-        dc = DataContainer(df, cc)
-
-        # Now extract the groupby and order information
+        # Extract the groupby and order information
         sort_columns, sort_ascending, sort_null_first = self._extract_ordering(
-            window, cc
+            dc, window
         )
         logger.debug(
             "Before applying the function, sorting according to {sort_columns}."
         )
 
-        df, group_columns = self._extract_groupby(df, window, dc, context)
+        dc, group_columns = self._extract_groupby(dc, window, context)
         logger.debug(
             f"Before applying the function, partitioning according to {group_columns}."
         )
@@ -141,14 +139,17 @@ class RexOverPlugin(BaseRexPlugin):
             except KeyError:  # pragma: no cover
                 raise NotImplementedError(f"{operator_name} not (yet) implemented")
 
-        logger.debug(f"Executing {operator_name} on {str(LoggableDataFrame(df))}")
+        logger.debug(f"Executing {operator_name} on {LoggableDataFrame(dc)}")
 
-        operands = [
-            RexConverter.convert(o, dc, context=context) for o in rex.getOperands()
-        ]
+        operands = []
+        for o in rex.getOperands():
+            new_column, dc = RexConverter.convert_to_column_reference(
+                o, dc, context=context
+            )
+            operands.append(new_column)
 
-        df, new_column_name = self._apply_function_over(
-            df,
+        new_column_name, dc = self._apply_function_over(
+            dc,
             operation,
             operands,
             group_columns,
@@ -157,12 +158,7 @@ class RexOverPlugin(BaseRexPlugin):
             sort_null_first,
         )
 
-        # Revert back any sorting and grouping by using the previously stored information
-        df = self._revert_partition_and_order(
-            df, partition_col, index_col, sort_col, known_divisions
-        )
-
-        return df[new_column_name]
+        return ColumnReference(new_column_name), dc
 
     def _assert_simple_window(self, window: org.apache.calcite.rex.RexWindow):
         """Make sure we can actually handle this window type"""
@@ -178,58 +174,44 @@ class RexOverPlugin(BaseRexPlugin):
             RexWindowBounds.UNBOUNDED_FOLLOWING,
         ], f"Lower window bound type {upper_bound} is not implemented"
 
-    def _preserve_index_and_sort(
-        self, df: dd.DataFrame
-    ) -> Tuple[dd.DataFrame, str, str, str]:
-        """Store the partition number, index and sort order separately to make any shuffling reversible"""
-        partition_col, index_col, sort_col = (
-            new_temporary_column(df),
-            new_temporary_column(df),
-            new_temporary_column(df),
-        )
-
-        def store_index_columns(partition, partition_index):
-            return partition.assign(
-                **{
-                    partition_col: partition_index,
-                    index_col: partition.index,
-                    sort_col: range(len(partition)),
-                }
-            )
-
-        df = map_on_partition_index(df, store_index_columns)
-
-        return df, partition_col, index_col, sort_col
-
     def _extract_groupby(
         self,
-        df: dd.DataFrame,
-        window: org.apache.calcite.rex.RexWindow,
         dc: DataContainer,
+        window: org.apache.calcite.rex.RexWindow,
         context: "dask_sql.Context",
-    ) -> Tuple[dd.DataFrame, str]:
+    ) -> Tuple[DataContainer, List[str]]:
         """Prepare grouping columns we can later use while applying the main function"""
+        df = dc.df
+
         partition_keys = list(window.partitionKeys)
-        if partition_keys:
-            group_columns = [
-                RexConverter.convert(o, dc, context=context) for o in partition_keys
-            ]
-            group_columns = get_groupby_with_nulls_cols(df, group_columns)
-            group_columns = {
-                new_temporary_column(df): group_col for group_col in group_columns
-            }
-        else:
-            group_columns = {new_temporary_column(df): 1}
+
+        group_columns = []
+        for o in partition_keys:
+            group_column, dc = RexConverter.convert_to_column_reference(
+                o, dc, context=context
+            )
+            group_columns.append(group_column)
+
+        group_columns = [g.get(dc) for g in group_columns]
+        df = dc.df
+        group_columns = get_groupby_with_nulls_cols(df, group_columns)
+        group_columns = {
+            new_temporary_column(df): group_col for group_col in group_columns
+        }
 
         df = df.assign(**group_columns)
         group_columns = list(group_columns.keys())
 
-        return df, group_columns
+        cc = dc.column_container
+        dc = DataContainer(df, cc)
+        return dc, group_columns
 
     def _extract_ordering(
-        self, window: org.apache.calcite.rex.RexWindow, cc: ColumnContainer
+        self, dc: DataContainer, window: org.apache.calcite.rex.RexWindow,
     ) -> Tuple[str, str, str]:
         """Prepare sorting information we can later use while applying the main function"""
+        cc = dc.column_container
+
         order_keys = list(window.orderKeys)
         sort_columns_indices = [int(i.getKey().getIndex()) for i in order_keys]
         sort_columns = [
@@ -245,22 +227,21 @@ class RexOverPlugin(BaseRexPlugin):
 
     def _apply_function_over(
         self,
-        df: dd.DataFrame,
+        dc: DataContainer,
         f: Callable,
-        operands: List[dd.Series],
+        operands: List[ColumnReference],
         group_columns: List[str],
         sort_columns: List[str],
         sort_ascending: List[bool],
         sort_null_first: List[bool],
-    ) -> Tuple[dd.DataFrame, str]:
+    ) -> Tuple[str, DataContainer]:
         """Apply the given function over the dataframe, possibly grouped and sorted per group"""
-        temporary_operand_columns = {
-            new_temporary_column(df): operand for operand in operands
-        }
-        df = df.assign(**temporary_operand_columns)
         # Important: move as few bytes as possible to the pickled function,
         # which is evaluated on the workers
-        temporary_operand_columns = temporary_operand_columns.keys()
+        operand_columns = [o._column_name for o in operands]
+
+        df = dc.df
+        new_column_name = new_temporary_column(df)
 
         def map_on_each_group(partitioned_group):
             if sort_columns:
@@ -268,37 +249,19 @@ class RexOverPlugin(BaseRexPlugin):
                     partitioned_group, sort_columns, sort_ascending, sort_null_first
                 )
 
-            column_result = f(partitioned_group, *temporary_operand_columns)
+            column_result = f(partitioned_group, *operand_columns)
             partitioned_group = partitioned_group.assign(
                 **{new_column_name: column_result}
             )
 
             return partitioned_group
 
-        new_column_name = new_temporary_column(df)
-
         meta = df._meta_nonempty.assign(**{new_column_name: 0.0})
         df = df.groupby(group_columns).apply(map_on_each_group, meta=meta)
 
-        return df, new_column_name
+        # Get rid of the multi-index (dask can not work with it well)
+        df = df.reset_index(drop=True)
 
-    def _revert_partition_and_order(
-        self,
-        df: dd.DataFrame,
-        partition_col: str,
-        index_col: str,
-        sort_col: str,
-        known_divisions: Any,
-    ) -> dd.DataFrame:
-        """Use the stored information to make revert the shuffling"""
-        from dask.dataframe.shuffle import set_partition
-
-        divisions = tuple(range(len(known_divisions)))
-        df = set_partition(df, partition_col, divisions)
-        df = df.map_partitions(
-            lambda x: x.set_index(index_col, drop=True).sort_values(sort_col),
-            meta=df._meta.set_index(index_col),
-        )
-        df.divisions = known_divisions
-
-        return df
+        cc = dc.column_container
+        dc = DataContainer(df, cc)
+        return new_column_name, dc

--- a/dask_sql/physical/utils/groupby.py
+++ b/dask_sql/physical/utils/groupby.py
@@ -6,7 +6,7 @@ from dask_sql.utils import new_temporary_column
 
 
 def get_groupby_with_nulls_cols(
-    df: dd.DataFrame, group_columns: List[str], additional_column_name: str = None
+    df: dd.DataFrame, group_columns: List[dd.Series], additional_column_name: str = None
 ):
     """
     SQL and dask are treating null columns a bit different:

--- a/tests/integration/test_over.py
+++ b/tests/integration/test_over.py
@@ -10,13 +10,14 @@ def test_over_with_sorting(c, user_table_1):
         user_id,
         ROW_NUMBER() OVER (ORDER BY user_id, b) AS R
     FROM user_table_1
+    ORDER BY user_id, b
     """
     )
     df = df.compute()
 
-    expected_df = pd.DataFrame({"user_id": user_table_1.user_id, "R": [3, 1, 2, 4]})
+    expected_df = pd.DataFrame({"user_id": [1, 2, 2, 3], "R": [1, 2, 3, 4]})
     expected_df["R"] = expected_df["R"].astype("Int64")
-    assert_frame_equal(df, expected_df)
+    assert_frame_equal(df.reset_index(drop=True), expected_df.reset_index(drop=True))
 
 
 def test_over_with_partitioning(c, user_table_2):
@@ -26,13 +27,14 @@ def test_over_with_partitioning(c, user_table_2):
         user_id,
         ROW_NUMBER() OVER (PARTITION BY c) AS R
     FROM user_table_2
+    ORDER BY user_id, c
     """
     )
     df = df.compute()
 
-    expected_df = pd.DataFrame({"user_id": user_table_2.user_id, "R": [1, 1, 1, 1]})
+    expected_df = pd.DataFrame({"user_id": [1, 1, 2, 4], "R": [1, 1, 1, 1]})
     expected_df["R"] = expected_df["R"].astype("Int64")
-    assert_frame_equal(df, expected_df)
+    assert_frame_equal(df.reset_index(drop=True), expected_df.reset_index(drop=True))
 
 
 def test_over_with_grouping_and_sort(c, user_table_1):
@@ -42,13 +44,14 @@ def test_over_with_grouping_and_sort(c, user_table_1):
         user_id,
         ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY b) AS R
     FROM user_table_1
+    ORDER BY user_id, b
     """
     )
     df = df.compute()
 
-    expected_df = pd.DataFrame({"user_id": user_table_1.user_id, "R": [2, 1, 1, 1]})
+    expected_df = pd.DataFrame({"user_id": [1, 2, 2, 3], "R": [1, 1, 2, 1]})
     expected_df["R"] = expected_df["R"].astype("Int64")
-    assert_frame_equal(df, expected_df)
+    assert_frame_equal(df.reset_index(drop=True), expected_df.reset_index(drop=True))
 
 
 def test_over_with_different(c, user_table_1):
@@ -59,16 +62,17 @@ def test_over_with_different(c, user_table_1):
         ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY b) AS R1,
         ROW_NUMBER() OVER (ORDER BY user_id, b) AS R2
     FROM user_table_1
+    ORDER BY user_id, b
     """
     )
     df = df.compute()
 
     expected_df = pd.DataFrame(
-        {"user_id": user_table_1.user_id, "R1": [2, 1, 1, 1], "R2": [3, 1, 2, 4],}
+        {"user_id": [1, 2, 2, 3], "R1": [1, 1, 2, 1], "R2": [1, 2, 3, 4],}
     )
     for col in ["R1", "R2"]:
         expected_df[col] = expected_df[col].astype("Int64")
-    assert_frame_equal(df, expected_df)
+    assert_frame_equal(df.reset_index(drop=True), expected_df.reset_index(drop=True))
 
 
 def test_over_calls(c):
@@ -86,22 +90,23 @@ def test_over_calls(c):
         MAX(b) OVER (PARTITION BY user_id ORDER BY b) AS O8,
         MIN(b) OVER (PARTITION BY user_id ORDER BY b) AS O9
     FROM user_table_1
+    ORDER BY user_id, b
     """
     )
     df = df.compute()
 
     expected_df = pd.DataFrame(
         {
-            "O1": [2, 1, 1, 1],
-            "O2": [19, 7, 19, 27],
-            "O3": [19, 7, 19, 27],
-            "O4": [17, 7, 17, 27],
-            "O5": [4, 1, 4, 3],
-            "O6": [2, 1, 2, 3],
-            "O7": [2, 1, 2, 1],
-            "O7b": [2, 1, 2, 1],
+            "O1": [1, 1, 2, 1],
+            "O2": [7, 19, 19, 27],
+            "O3": [7, 19, 19, 27],
+            "O4": [7, 17, 17, 27],
+            "O5": [1, 4, 4, 3],
+            "O6": [1, 2, 2, 3],
+            "O7": [1, 2, 2, 1],
+            "O7b": [1, 2, 2, 1],
             "O8": [3, 3, 3, 3],
-            "O9": [1, 3, 1, 3],
+            "O9": [3, 1, 1, 3],
         }
     )
     for col in expected_df.columns:
@@ -109,4 +114,4 @@ def test_over_calls(c):
             continue
         expected_df[col] = expected_df[col].astype("Int64")
     expected_df["O6"] = expected_df["O6"].astype("float64")
-    assert_frame_equal(df, expected_df)
+    assert_frame_equal(df.reset_index(drop=True), expected_df.reset_index(drop=True))


### PR DESCRIPTION
Background: In LogicalProjects, so far each column got calculated independently and was assigned simultaneously at the end.

This, unfortunately, means, that more complex operations such as "OVER" need to do a lot of shuffling and book-keeping, as they need to keep track of the original order (otherwise the columns will not fit together).

This PR changes this behavior by adding the columns immediately to the data frame, allowing to re-sort the data frame if
needed.