### PR TITLE
Register the lower and upper-case version of a function

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -710,7 +710,7 @@ class Context:
         if lower_name in self.functions:
             if replace:
                 self.function_list = list(
-                    filter(lambda f: f.name != name, self.function_list)
+                    filter(lambda f: f.name.lower() != lower_name, self.function_list)
                 )
                 del self.functions[lower_name]
 
@@ -720,6 +720,9 @@ class Context:
                 )
 
         self.function_list.append(
-            FunctionDescription(name, parameters, return_type, aggregation)
+            FunctionDescription(name.upper(), parameters, return_type, aggregation)
         )
-        self.functions[name] = f
+        self.function_list.append(
+            FunctionDescription(name.lower(), parameters, return_type, aggregation)
+        )
+        self.functions[lower_name] = f

--- a/tests/integration/test_function.py
+++ b/tests/integration/test_function.py
@@ -12,7 +12,7 @@ def test_custom_function(c, df):
 
     return_df = c.sql(
         """
-        SELECT f(a) AS a
+        SELECT F(a) AS a
         FROM df
         """
     )
@@ -30,13 +30,29 @@ def test_multiple_definitions(c, df_simple):
 
     return_df = c.sql(
         """
-        SELECT f(a) AS a, f(b) AS b
+        SELECT F(a) AS a, f(b) AS b
         FROM df_simple
         """
     )
     return_df = return_df.compute()
 
     assert_frame_equal(return_df.reset_index(drop=True), df_simple[["a", "b"]] ** 2)
+
+    def f(x):
+        return x ** 3
+
+    c.register_function(f, "f", [("x", np.float64)], np.float64, replace=True)
+    c.register_function(f, "f", [("x", np.int64)], np.int64)
+
+    return_df = c.sql(
+        """
+        SELECT F(a) AS a, f(b) AS b
+        FROM df_simple
+        """
+    )
+    return_df = return_df.compute()
+
+    assert_frame_equal(return_df.reset_index(drop=True), df_simple[["a", "b"]] ** 3)
 
 
 def test_aggregate_function(c):
@@ -45,7 +61,7 @@ def test_aggregate_function(c):
 
     return_df = c.sql(
         """
-        SELECT fagg(b) AS test, sum(b) AS "S"
+        SELECT FAGG(b) AS test, SUM(b) AS "S"
         FROM df
         """
     )

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -162,22 +162,30 @@ def test_function_adding():
 
     assert "f" in c.functions
     assert c.functions["f"] == f
-    assert len(c.function_list) == 1
-    assert c.function_list[0].name == "f"
+    assert len(c.function_list) == 2
+    assert c.function_list[0].name == "F"
     assert c.function_list[0].parameters == [("x", int)]
     assert c.function_list[0].return_type == float
     assert not c.function_list[0].aggregation
+    assert c.function_list[1].name == "f"
+    assert c.function_list[1].parameters == [("x", int)]
+    assert c.function_list[1].return_type == float
+    assert not c.function_list[1].aggregation
 
     # Without replacement
     c.register_function(f, "f", [("x", float)], int, replace=False)
 
     assert "f" in c.functions
     assert c.functions["f"] == f
-    assert len(c.function_list) == 2
-    assert c.function_list[1].name == "f"
-    assert c.function_list[1].parameters == [("x", float)]
-    assert c.function_list[1].return_type == int
-    assert not c.function_list[1].aggregation
+    assert len(c.function_list) == 4
+    assert c.function_list[2].name == "F"
+    assert c.function_list[2].parameters == [("x", float)]
+    assert c.function_list[2].return_type == int
+    assert not c.function_list[2].aggregation
+    assert c.function_list[3].name == "f"
+    assert c.function_list[3].parameters == [("x", float)]
+    assert c.function_list[3].return_type == int
+    assert not c.function_list[3].aggregation
 
     # With replacement
     f = lambda x: x + 1
@@ -185,11 +193,15 @@ def test_function_adding():
 
     assert "f" in c.functions
     assert c.functions["f"] == f
-    assert len(c.function_list) == 1
-    assert c.function_list[0].name == "f"
+    assert len(c.function_list) == 2
+    assert c.function_list[0].name == "F"
     assert c.function_list[0].parameters == [("x", str)]
     assert c.function_list[0].return_type == str
     assert not c.function_list[0].aggregation
+    assert c.function_list[1].name == "f"
+    assert c.function_list[1].parameters == [("x", str)]
+    assert c.function_list[1].return_type == str
+    assert not c.function_list[1].aggregation
 
 
 def test_aggregation_adding():
@@ -203,22 +215,30 @@ def test_aggregation_adding():
 
     assert "f" in c.functions
     assert c.functions["f"] == f
-    assert len(c.function_list) == 1
-    assert c.function_list[0].name == "f"
+    assert len(c.function_list) == 2
+    assert c.function_list[0].name == "F"
     assert c.function_list[0].parameters == [("x", int)]
     assert c.function_list[0].return_type == float
     assert c.function_list[0].aggregation
+    assert c.function_list[1].name == "f"
+    assert c.function_list[1].parameters == [("x", int)]
+    assert c.function_list[1].return_type == float
+    assert c.function_list[1].aggregation
 
     # Without replacement
     c.register_aggregation(f, "f", [("x", float)], int, replace=False)
 
     assert "f" in c.functions
     assert c.functions["f"] == f
-    assert len(c.function_list) == 2
-    assert c.function_list[1].name == "f"
-    assert c.function_list[1].parameters == [("x", float)]
-    assert c.function_list[1].return_type == int
-    assert c.function_list[1].aggregation
+    assert len(c.function_list) == 4
+    assert c.function_list[2].name == "F"
+    assert c.function_list[2].parameters == [("x", float)]
+    assert c.function_list[2].return_type == int
+    assert c.function_list[2].aggregation
+    assert c.function_list[3].name == "f"
+    assert c.function_list[3].parameters == [("x", float)]
+    assert c.function_list[3].return_type == int
+    assert c.function_list[3].aggregation
 
     # With replacement
     f = lambda x: x + 1
@@ -226,8 +246,12 @@ def test_aggregation_adding():
 
     assert "f" in c.functions
     assert c.functions["f"] == f
-    assert len(c.function_list) == 1
-    assert c.function_list[0].name == "f"
+    assert len(c.function_list) == 2
+    assert c.function_list[0].name == "F"
     assert c.function_list[0].parameters == [("x", str)]
     assert c.function_list[0].return_type == str
     assert c.function_list[0].aggregation
+    assert c.function_list[1].name == "f"
+    assert c.function_list[1].parameters == [("x", str)]
+    assert c.function_list[1].return_type == str
+    assert c.function_list[1].aggregation


### PR DESCRIPTION
This allows to call both
```sql
SELECT F(x) FROM data
```
as well as
```sql
SELECT f(x) FROM data
```
no matter how the function was registered