### PR TITLE
Sarg and search

### DIFF
--- a/dask_sql/physical/rex/core/literal.py
+++ b/dask_sql/physical/rex/core/literal.py
@@ -4,8 +4,71 @@ import dask.dataframe as dd
 import numpy as np
 
 from dask_sql.datacontainer import DataContainer
+from dask_sql.java import com, org
 from dask_sql.mappings import sql_to_python_value
 from dask_sql.physical.rex.base import BaseRexPlugin
+
+
+class SargPythonImplementation:
+    """
+    Apache Calcite comes with a Sarg literal, which stands for the
+    "search arguments" (which are later used in a SEARCH call).
+    We transform it into a more manageable python object
+    by extracting the Java properties.
+    """
+
+    class Range:
+        """Helper class to represent one of the ranges in a Sarg object"""
+
+        def __init__(self, range: com.google.common.collect.Range, literal_type: str):
+            self.lower_endpoint = None
+            self.lower_open = True
+            if range.hasLowerBound():
+                self.lower_endpoint = sql_to_python_value(
+                    literal_type, range.lowerEndpoint()
+                )
+                self.lower_open = (
+                    range.lowerBoundType() == com.google.common.collect.BoundType.OPEN
+                )
+
+            self.upper_endpoint = None
+            self.upper_open = True
+            if range.hasUpperBound():
+                self.upper_endpoint = sql_to_python_value(
+                    literal_type, range.upperEndpoint()
+                )
+                self.upper_open = (
+                    range.upperBoundType() == com.google.common.collect.BoundType.OPEN
+                )
+
+        def filter_on(self, series: dd.Series):
+            lower_condition = True
+            if self.lower_endpoint is not None:
+                if self.lower_open:
+                    lower_condition = self.lower_endpoint < series
+                else:
+                    lower_condition = self.lower_endpoint <= series
+
+            upper_condition = True
+            if self.upper_endpoint is not None:
+                if self.upper_open:
+                    upper_condition = self.upper_endpoint > series
+                else:
+                    upper_condition = self.upper_endpoint >= series
+
+            return lower_condition & upper_condition
+
+        def __repr__(self) -> str:
+            return f"Range {self.lower_endpoint} - {self.upper_endpoint}"
+
+    def __init__(self, java_sarg: org.apache.calcite.util.Sarg, literal_type: str):
+        self.ranges = [
+            SargPythonImplementation.Range(r, literal_type)
+            for r in java_sarg.rangeSet.asRanges()
+        ]
+
+    def __repr__(self) -> str:
+        return ",".join(map(str, self.ranges))
 
 
 class RexLiteralPlugin(BaseRexPlugin):
@@ -29,6 +92,10 @@ class RexLiteralPlugin(BaseRexPlugin):
         literal_value = rex.getValue()
 
         literal_type = str(rex.getType())
+
+        if isinstance(literal_value, org.apache.calcite.util.Sarg):
+            return SargPythonImplementation(literal_value, literal_type)
+
         python_value = sql_to_python_value(literal_type, literal_value)
 
         return python_value

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -14,7 +14,14 @@ def test_case(c, df):
         (CASE WHEN a = 3 THEN 1 END) AS "S1",
         (CASE WHEN a > 0 THEN a ELSE 1 END) AS "S2",
         (CASE WHEN a = 4 THEN 3 ELSE a + 1 END) AS "S3",
-        (CASE WHEN a = 3 THEN 1 WHEN a > 0 THEN 2 ELSE a END) AS "S4"
+        (CASE WHEN a = 3 THEN 1 WHEN a > 0 THEN 2 ELSE a END) AS "S4",
+        CASE
+            WHEN (a >= 1 AND a < 2) OR (a > 2) THEN CAST('in-between' AS VARCHAR) ELSE CAST('out-of-range' AS VARCHAR)
+        END AS "S5",
+        CASE
+            WHEN (a < 2) OR (3 < a AND a < 4) THEN 42 ELSE 47
+        END AS "S6",
+        CASE WHEN (1 < a AND a <= 4) THEN 1 ELSE 0 END AS "S7"
     FROM df
     """
     )
@@ -27,6 +34,11 @@ def test_case(c, df):
     expected_df["S4"] = df.a.apply(lambda a: 1 if a == 3 else 2 if a > 0 else a).astype(
         "float64"
     )
+    expected_df["S5"] = df.a.apply(
+        lambda a: "in-between" if ((1 <= a < 2) or (a > 2)) else "out-of-range"
+    )
+    expected_df["S6"] = df.a.apply(lambda a: 42 if ((a < 2) or (3 < a < 4)) else 47)
+    expected_df["S7"] = df.a.apply(lambda a: 1 if (1 < a <= 4) else 0)
     assert_frame_equal(result_df, expected_df)
 
 


### PR DESCRIPTION
Fixes #175 

`SEARCH` is a not-so-frequent SQL operation, but Calcite uses it internally for optimizing calls such as shown in the issue.
This PR implements in implementation for the search operation as well as the Search Args (Sargs).

I tried to cover some edge cases like infinity, but I am not sure if I caught all of them.