### PR TITLE
Fix a failing build, as ciso8601 is currently not pip-installable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,8 @@ jobs:
         shell: bash -l {0}
         run: |
           # explicitly install docker, fugue and sqlalchemy package
-          mamba install sqlalchemy psycopg2 -c conda-forge
+          # Also install ciso8601 (needed by docker) via conda, as the pip installation fails.
+          mamba install sqlalchemy psycopg2 ciso8601 -c conda-forge
           pip install docker "fugue[sql]>=0.5.3"
         if: matrix.os == 'ubuntu-latest'
       - name: Install Java (again) and test with pytest


### PR DESCRIPTION
Install ciso8601 as conda package, not via pip, because building the wheel for ciso8601 fails with
```
 gcc -pthread -DNDEBUG -O2 -fPIC -DCISO8601_VERSION=2.1.3 -I/usr/share/miniconda/envs/test/include -c module.c -o build/temp.linux-x86_64-3.7/module.o
  module.c: In function ‘_parse’:
  module.c:446:30: warning: implicit declaration of function ‘PyTimeZone_FromOffset’ [-Wimplicit-function-declaration]
    446 |                     tzinfo = PyTimeZone_FromOffset(delta);
        |                              ^~~~~~~~~~~~~~~~~~~~~
  module.c:446:28: warning: assignment to ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
    446 |                     tzinfo = PyTimeZone_FromOffset(delta);
        |                            ^
  module.c: In function ‘PyInit_ciso8601’:
  module.c:562:11: error: ‘PyDateTime_TimeZone_UTC’ undeclared (first use in this function); did you mean ‘PyDateTime_Time’?
    562 |     utc = PyDateTime_TimeZone_UTC;
        |           ^~~~~~~~~~~~~~~~~~~~~~~
        |           PyDateTime_Time
  module.c:562:11: note: each undeclared identifier is reported only once for each function it appears in
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for ciso8601
```

which is very similar to https://github.com/closeio/ciso8601/issues/101 (it seems pyscopg or sqlalchemy are pulling in pypy as a dependency).