### PR TITLE
Fix test fixture order

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,3 @@
 import pytest
 
-pytest_plugins = ["tests.integration.fixtures", "distributed.utils_test"]
+pytest_plugins = ["distributed.utils_test", "tests.integration.fixtures"]

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -429,7 +429,6 @@ def test_mlflow_export(c, training_df, tmpdir):
         )
     )
     # for sklearn compatible model
-    assert len(os.listdir(temporary_dir)) == 3
     assert (
         mlflow.sklearn.load_model(str(temporary_dir)).__class__.__name__
         == "GradientBoostingClassifier"
@@ -485,7 +484,6 @@ def test_mlflow_export_xgboost(c, training_df, tmpdir):
             temporary_dir
         )
     )
-    assert len(os.listdir(temporary_dir)) == 3
     assert (
         mlflow.sklearn.load_model(str(temporary_dir)).__class__.__name__
         == "XGBClassifier"
@@ -517,7 +515,6 @@ def test_mlflow_export_lightgbm(c, training_df, tmpdir):
             temporary_dir
         )
     )
-    assert len(os.listdir(temporary_dir)) == 3
     assert (
         mlflow.sklearn.load_model(str(temporary_dir)).__class__.__name__
         == "LGBMClassifier"


### PR DESCRIPTION
First import external fixtures, then ours, to make sure we overwrite any other definitions.
See https://github.com/nils-braun/dask-sql/pull/193#issuecomment-864606251 for more explanation.