### PR TITLE
Fixes for pandas 1.3.0

### DIFF
--- a/.github/docker-compose.yaml
+++ b/.github/docker-compose.yaml
@@ -8,10 +8,10 @@ services:
         ports:
             - "8786:8786"
         environment:
-            EXTRA_CONDA_PACKAGES: "pandas>=1.2 numpy=1.20.2 -c conda-forge"
+            EXTRA_CONDA_PACKAGES: "pandas>=1.3 numpy=1.20.2 -c conda-forge"
     dask-worker:
         container_name: dask-worker
         image: daskdev/dask:latest
         command: dask-worker dask-scheduler:8786
         environment:
-            EXTRA_CONDA_PACKAGES: "pandas>=1.2 numpy=1.20.2 -c conda-forge"
+            EXTRA_CONDA_PACKAGES: "pandas>=1.3 numpy=1.20.2 -c conda-forge"

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -112,19 +112,17 @@ def test_group_by_case(c):
     df = c.sql(
         """
     SELECT
-        user_id + 1, SUM(CASE WHEN b = 3 THEN 1 END) AS "S"
+        user_id + 1 AS "A", SUM(CASE WHEN b = 3 THEN 1 END) AS "S"
     FROM user_table_1
     GROUP BY user_id + 1
     """
     )
     df = df.compute()
 
-    user_id_column = '"user_table_1"."user_id" + 1'
-
-    expected_df = pd.DataFrame({user_id_column: [2, 3, 4], "S": [1, 1, 1]})
-    expected_df[user_id_column] = expected_df[user_id_column].astype("int64")
+    expected_df = pd.DataFrame({"A": [2, 3, 4], "S": [1, 1, 1]})
+    # Do not check dtypes, as pandas versions are inconsistent here
     assert_frame_equal(
-        df.sort_values(user_id_column).reset_index(drop=True), expected_df
+        df.sort_values("A").reset_index(drop=True), expected_df, check_dtype=False
     )
 
 

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -31,15 +31,14 @@ def test_case(c, df):
     expected_df["S1"] = df.a.apply(lambda a: 1 if a == 3 else pd.NA)
     expected_df["S2"] = df.a.apply(lambda a: a if a > 0 else 1)
     expected_df["S3"] = df.a.apply(lambda a: 3 if a == 4 else a + 1)
-    expected_df["S4"] = df.a.apply(lambda a: 1 if a == 3 else 2 if a > 0 else a).astype(
-        "float64"
-    )
+    expected_df["S4"] = df.a.apply(lambda a: 1 if a == 3 else 2 if a > 0 else a)
     expected_df["S5"] = df.a.apply(
         lambda a: "in-between" if ((1 <= a < 2) or (a > 2)) else "out-of-range"
     )
     expected_df["S6"] = df.a.apply(lambda a: 42 if ((a < 2) or (3 < a < 4)) else 47)
     expected_df["S7"] = df.a.apply(lambda a: 1 if (1 < a <= 4) else 0)
-    assert_frame_equal(result_df, expected_df)
+    # Do not check dtypes, as pandas versions are inconsistent here
+    assert_frame_equal(result_df, expected_df, check_dtype=False)
 
 
 def test_literals(c):


### PR DESCRIPTION
The recently released pandas 1.3.0 introduces some changes to how `where` treats types (not sure if a bug or a feature, in some way both are correct): for example a SQL like `CASE WHEN a = 3 THEN 1 END` does now return a `float64`.

This PR therefore turns off the dtype checking for some of the test cases and therefore fixes the CI/CD error seen in #199 