### PR TITLE
Updates to `aggregate.py` and `join.py`

### DIFF
--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -1,3 +1,24 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import logging
 import operator
 from collections import defaultdict

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -341,15 +341,18 @@ class LogicalAggregatePlugin(BaseRelPlugin):
         grouped_df = tmp_df.groupby(by=group_columns_and_nulls)
 
         # Convert into the correct format for dask
-        aggregations_dict = defaultdict(dict)
+        aggregations_dict = defaultdict(list)
+        input_output_cols = []
         for aggregation in aggregations:
             input_col, output_col, aggregation_f = aggregation
 
-            aggregations_dict[input_col][output_col] = aggregation_f
+            aggregations_dict[input_col].append(aggregation_f)
+            input_output_cols.append((input_col, output_col))
 
         # Now apply the aggregation
         logger.debug(f"Performing aggregation {dict(aggregations_dict)}")
         agg_result = grouped_df.agg(aggregations_dict)
+        agg_result.columns = input_output_cols
 
         # ... fix the column names to a single level ...
         agg_result.columns = agg_result.columns.get_level_values(-1)

--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -1,3 +1,24 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import logging
 import operator
 import warnings
@@ -117,7 +138,7 @@ class LogicalJoinPlugin(BaseRelPlugin):
                 # which is definitely not possible (java dependency, JVM start...)
                 lhs_partition = lhs_partition.assign(common=1)
                 rhs_partition = rhs_partition.assign(common=1)
-                merged_data = pd.merge(lhs_partition, rhs_partition, on=["common"])
+                merged_data = dd.multi.merge(lhs_partition, rhs_partition, on=["common"])
 
                 return merged_data
 
@@ -137,7 +158,7 @@ class LogicalJoinPlugin(BaseRelPlugin):
                 name, dsk, dependencies=[df_lhs_renamed, df_rhs_renamed]
             )
 
-            meta = pd.concat(
+            meta = dd.dispatch.concat(
                 [df_lhs_renamed._meta_nonempty, df_rhs_renamed._meta_nonempty], axis=1
             )
             # TODO: Do we know the divisions in any way here?


### PR DESCRIPTION
Two files have been modified here: 

1. In `aggregate.py`, I changed `_perform_aggregation()` to construct a dict-of-lists, rather than a dict-of-dicts. Although Dask still supports the ability to pass a dict-of-dicts into `groupby().agg()`, Pandas previously deprecated and has now removed this functionality (see here: https://pandas.pydata.org/pandas-docs/stable/whatsnew/v0.20.0.html#deprecate-groupby-agg-with-a-dictionary-when-renaming). 
2. In `join.py`, there were a couple function calls that were Pandas-specific, so I changed them to call to `dask.dataframe` instead.

Let me know what you think!