### PR TITLE
Remove mandatory dask_ml dependencies

### DIFF
--- a/dask_sql/physical/rel/custom/create_experiment.py
+++ b/dask_sql/physical/rel/custom/create_experiment.py
@@ -164,7 +164,7 @@ class CreateExperimentPlugin(BaseRelPlugin):
 
             try:
                 from dask_ml.wrappers import ParallelPostFit
-            except ImportError:
+            except ImportError:  # pragma: no cover
                 raise ValueError(
                     "dask_ml must be installed to use automl and tune hyperparameters"
                 )
@@ -195,7 +195,7 @@ class CreateExperimentPlugin(BaseRelPlugin):
 
             try:
                 from dask_ml.wrappers import ParallelPostFit
-            except ImportError:
+            except ImportError:  # pragma: no cover
                 raise ValueError(
                     "dask_ml must be installed to use automl and tune hyperparameters"
                 )

--- a/dask_sql/physical/rel/custom/create_experiment.py
+++ b/dask_sql/physical/rel/custom/create_experiment.py
@@ -2,7 +2,6 @@ import logging
 
 import dask.dataframe as dd
 import pandas as pd
-from dask_ml.wrappers import ParallelPostFit
 
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.java import org
@@ -163,6 +162,13 @@ class CreateExperimentPlugin(BaseRelPlugin):
                     f"Can not import tuner {experiment_class}. Make sure you spelled it correctly and have installed all packages."
                 )
 
+            try:
+                from dask_ml.wrappers import ParallelPostFit
+            except ImportError:
+                raise ValueError(
+                    "dask_ml must be installed to use automl and tune hyperparameters"
+                )
+
             model = ModelClass()
 
             search = ExperimentClass(model, {**parameters}, **experiment_kwargs)
@@ -186,6 +192,14 @@ class CreateExperimentPlugin(BaseRelPlugin):
                 raise ValueError(
                     f"Can not import automl model {automl_class}. Make sure you spelled it correctly and have installed all packages."
                 )
+
+            try:
+                from dask_ml.wrappers import ParallelPostFit
+            except ImportError:
+                raise ValueError(
+                    "dask_ml must be installed to use automl and tune hyperparameters"
+                )
+
             automl = AutoMLClass(**automl_kwargs)
             # should be avoided if  data doesn't fit in memory
             automl.fit(X.compute(), y.compute())

--- a/dask_sql/physical/rel/custom/create_model.py
+++ b/dask_sql/physical/rel/custom/create_model.py
@@ -139,12 +139,18 @@ class CreateModelPlugin(BaseRelPlugin):
 
         model = ModelClass(**kwargs)
         if wrap_fit:
-            from dask_ml.wrappers import Incremental
+            try:
+                from dask_ml.wrappers import Incremental
+            except ImportError:
+                raise ValueError("Wrapping requires dask-ml to be installed.")
 
             model = Incremental(estimator=model)
 
         if wrap_predict:
-            from dask_ml.wrappers import ParallelPostFit
+            try:
+                from dask_ml.wrappers import ParallelPostFit
+            except ImportError:
+                raise ValueError("Wrapping requires dask-ml to be installed.")
 
             model = ParallelPostFit(estimator=model)
 

--- a/dask_sql/physical/rel/custom/create_model.py
+++ b/dask_sql/physical/rel/custom/create_model.py
@@ -141,7 +141,7 @@ class CreateModelPlugin(BaseRelPlugin):
         if wrap_fit:
             try:
                 from dask_ml.wrappers import Incremental
-            except ImportError:
+            except ImportError:  # pragma: no cover
                 raise ValueError("Wrapping requires dask-ml to be installed.")
 
             model = Incremental(estimator=model)
@@ -149,7 +149,7 @@ class CreateModelPlugin(BaseRelPlugin):
         if wrap_predict:
             try:
                 from dask_ml.wrappers import ParallelPostFit
-            except ImportError:
+            except ImportError:  # pragma: no cover
                 raise ValueError("Wrapping requires dask-ml to be installed.")
 
             model = ParallelPostFit(estimator=model)


### PR DESCRIPTION
The [conda-forge build](https://github.com/conda-forge/dask-sql-feedstock/pull/14#issuecomment-896514884) for 0.3.7 failed due to a mandatory dependency on dask-ml, which is not mentioned in our requirements. I am making the dependency optional here. 